### PR TITLE
Fix metadata provider sync across manual flows

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -37,6 +37,25 @@ let llmClient: OpenAIClient;
 let llmEngine: LLMEngine;
 let regexEngine: RegexEngine;
 
+function buildMetadataProvider() {
+  const currentTmdbKey = store.get('tmdb_api_key') as string || '';
+  const currentProxyUrl = store.get('proxy_url') as string || '';
+  const provider = MetadataFactory.create('tmdb', { apiKey: currentTmdbKey });
+
+  if ('setProxy' in provider) (provider as any).setProxy(currentProxyUrl);
+
+  return provider;
+}
+
+function syncMetadataProvider() {
+  metadataProvider = buildMetadataProvider();
+
+  if (scannerService) {
+    scannerService.setMetadataProvider(metadataProvider);
+    scannerService.setProxy(store.get('proxy_url') as string || '');
+  }
+}
+
 function registerIpcHandlers() {
   ipcMain.handle('config:get', (_, key) => store.get(key));
   ipcMain.handle('config:set', async (_, key, value) => {
@@ -47,6 +66,9 @@ function registerIpcHandlers() {
     }
     if (key === 'log_level' && scannerService) {
       scannerService.setLogLevel(value as any);
+    }
+    if ((key === 'tmdb_api_key' || key === 'proxy_url') && scannerService) {
+      syncMetadataProvider();
     }
   });
 
@@ -145,18 +167,13 @@ function registerIpcHandlers() {
       const connected = await source.connect(connectConfig);
       if (!connected) return { success: false, error: '连接失败' };
 
-      const currentTmdbKey = store.get('tmdb_api_key') as string || '';
       const currentOpenaiKey = store.get('openai_api_key') as string || '';
       const currentOpenaiBase = store.get('openai_base_url') as string || '';
       const currentOpenaiModel = store.get('openai_model') as string || '';
       const currentProxyUrl = store.get('proxy_url') as string || '';
 
       llmClient.configure({ apiKey: currentOpenaiKey, baseURL: currentOpenaiBase, model: currentOpenaiModel, proxyUrl: currentProxyUrl });
-      const newMetadataProvider = MetadataFactory.create('tmdb', { apiKey: currentTmdbKey });
-      if ('setProxy' in newMetadataProvider) (newMetadataProvider as any).setProxy(currentProxyUrl);
-
-      scannerService.setMetadataProvider(newMetadataProvider);
-      scannerService.setProxy(currentProxyUrl);
+      syncMetadataProvider();
 
       // 设置 OpenList 批次大小
       const batchSize = store.get('openlist_batch_size') as string || '20';
@@ -177,14 +194,13 @@ function registerIpcHandlers() {
       const connected = await source.connect(connectConfig);
       if (!connected) return { success: false, error: '连接失败' };
 
-      const currentTmdbKey = store.get('tmdb_api_key') as string || '';
       const currentOpenaiKey = store.get('openai_api_key') as string || '';
       const currentOpenaiBase = store.get('openai_base_url') as string || '';
       const currentOpenaiModel = store.get('openai_model') as string || '';
+      const currentProxyUrl = store.get('proxy_url') as string || '';
 
-      llmClient.configure({ apiKey: currentOpenaiKey, baseURL: currentOpenaiBase, model: currentOpenaiModel });
-      const newMetadataProvider = MetadataFactory.create('tmdb', { apiKey: currentTmdbKey });
-      scannerService.setMetadataProvider(newMetadataProvider);
+      llmClient.configure({ apiKey: currentOpenaiKey, baseURL: currentOpenaiBase, model: currentOpenaiModel, proxyUrl: currentProxyUrl });
+      syncMetadataProvider();
 
       // 设置 OpenList 批次大小
       const batchSize = store.get('openlist_batch_size') as string || '20';
@@ -205,14 +221,13 @@ function registerIpcHandlers() {
       const connected = await source.connect(connectConfig);
       if (!connected) return { success: false, error: '连接失败' };
 
-      const currentTmdbKey = store.get('tmdb_api_key') as string || '';
       const currentOpenaiKey = store.get('openai_api_key') as string || '';
       const currentOpenaiBase = store.get('openai_base_url') as string || '';
       const currentOpenaiModel = store.get('openai_model') as string || '';
+      const currentProxyUrl = store.get('proxy_url') as string || '';
 
-      llmClient.configure({ apiKey: currentOpenaiKey, baseURL: currentOpenaiBase, model: currentOpenaiModel });
-      const newMetadataProvider = MetadataFactory.create('tmdb', { apiKey: currentTmdbKey });
-      scannerService.setMetadataProvider(newMetadataProvider);
+      llmClient.configure({ apiKey: currentOpenaiKey, baseURL: currentOpenaiBase, model: currentOpenaiModel, proxyUrl: currentProxyUrl });
+      syncMetadataProvider();
 
       // 设置 OpenList 批次大小
       const batchSize = store.get('openlist_batch_size') as string || '20';
@@ -386,17 +401,14 @@ app.whenReady().then(() => {
   llmClient = new OpenAIClient();
   llmEngine = new LLMEngine(llmClient);
 
-  const tmdbKeyInitial = store.get('tmdb_api_key') as string || '';
-  metadataProvider = MetadataFactory.create('tmdb', { apiKey: tmdbKeyInitial });
+  metadataProvider = buildMetadataProvider();
 
   scannerService = new ScannerService(regexEngine, llmEngine, metadataProvider, dbService);
 
   const savedLogLevel = store.get('log_level') as string || 'info';
   scannerService.setLogLevel(savedLogLevel as any);
 
-  const savedProxyUrl = store.get('proxy_url') as string || '';
-  scannerService.setProxy(savedProxyUrl);
-  if (metadataProvider.setProxy) (metadataProvider as any).setProxy(savedProxyUrl);
+  syncMetadataProvider();
 
   // Initialize Update Service
   updateService = new UpdateService(store);

--- a/electron/services/ScannerService.ts
+++ b/electron/services/ScannerService.ts
@@ -164,7 +164,8 @@ export class ScannerService {
     this.log(`正在识别上下文: ${targetPath} `);
 
     try {
-      const dirPath = path.posix.dirname(targetPath);
+      const pathApi = source.type === 'local' ? path : path.posix;
+      const dirPath = pathApi.dirname(targetPath);
       const allFiles = await source.listDir(dirPath);
 
       const extPattern = videoExtensions.split(',').map(e => e.trim()).filter(e => e).join('|');
@@ -188,7 +189,7 @@ export class ScannerService {
       const items: any[] = [];
       for (const file of videoFiles) {
         // Only process the target file
-        if (file.name !== path.basename(targetPath)) continue;
+        if (file.name !== pathApi.basename(targetPath)) continue;
 
         const match = resolveResult.matches.find(m => m.filename === file.name);
         items.push({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -242,11 +242,17 @@ export default function App() {
       refreshMedia();
     };
     const handleConfirmation = (data: any) => {
+      setMetadataFetched(false);
+      setFetchingMetadata(false);
+      setMetadataProgress({ current: 0, total: 0 });
       setWizardData({ detectedName: data.detectedName, seriesResults: data.results });
       setManualSeriesName(data.detectedName); // Initialize with detected name
       setWizardWizardStage('series');
     };
     const handleEpisodesConfirmation = (data: any) => {
+      setMetadataFetched(false);
+      setFetchingMetadata(false);
+      setMetadataProgress({ current: 0, total: 0 });
       setWizardData(prev => ({
         ...prev,
         seriesName: data.seriesName,
@@ -361,6 +367,9 @@ export default function App() {
     setWizardWizardStage('idle');
     setWizardData({});
     setScrapeProgress({ percent: 0, message: '' });
+    setMetadataFetched(false);
+    setFetchingMetadata(false);
+    setMetadataProgress({ current: 0, total: 0 });
 
     if (wizardStage === 'finished') {
       setScanning(false);


### PR DESCRIPTION
## Summary
- rebuild and sync the TMDB metadata provider whenever the TMDB key or proxy changes
- make manual metadata fetch/detail flows use the same live provider as scan flows
- apply proxy configuration consistently across scan-selected and identify-single
- reset manual metadata UI state when opening a new confirmation flow
- align local single-file identify path handling with local directory scans

## Testing
- manual verification: changing TMDB key now fails and recovers without restarting the app
- manual verification: episode detail and manual metadata fetch behave consistently
- manual verification: metadata fetch button reappears correctly on subsequent selected-file matches

Fixes #3