### PR TITLE
Fix manual series re-search flow

### DIFF
--- a/electron/metadata/TMDBProvider.ts
+++ b/electron/metadata/TMDBProvider.ts
@@ -7,6 +7,7 @@ export class TMDBProvider implements IMetadataProvider {
   private apiKey: string;
   private api: FetchClient;
   private imageBaseUrl: string = 'https://image.tmdb.org/t/p/w500';
+  private readonly fallbackLanguages = ['zh-CN', 'en-US'];
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
@@ -63,26 +64,54 @@ export class TMDBProvider implements IMetadataProvider {
 
   async searchTVShow(query: string): Promise<SearchResult[]> {
     try {
-      // Clean query: remove trailing hyphens and extra spaces
-      const cleanQuery = query.replace(/[-\s]+$/, '').trim();
+      const seen = new Set<string>();
+      const aggregatedResults: SearchResult[] = [];
 
-      const response = await this.api.get('/search/tv', {
-        params: { query: cleanQuery },
-      });
+      for (const language of this.fallbackLanguages) {
+        for (const candidate of this.buildSearchCandidates(query)) {
+          const response = await this.api.get('/search/tv', {
+            params: { query: candidate, language },
+          });
 
-      return response.data.results.map((item: any) => ({
-        id: item.id.toString(),
-        title: item.name,
-        originalTitle: item.original_name,
-        year: item.first_air_date ? item.first_air_date.substring(0, 4) : undefined,
-        poster: item.poster_path ? `${this.imageBaseUrl}${item.poster_path}` : undefined,
-        overview: item.overview,
-        provider: 'tmdb',
-      }));
+          const results = response.data.results.map((item: any) => ({
+            id: item.id.toString(),
+            title: item.name,
+            originalTitle: item.original_name,
+            year: item.first_air_date ? item.first_air_date.substring(0, 4) : undefined,
+            poster: item.poster_path ? `${this.imageBaseUrl}${item.poster_path}` : undefined,
+            overview: item.overview,
+            provider: 'tmdb',
+          }));
+
+          for (const result of results) {
+            if (!seen.has(result.id)) {
+              seen.add(result.id);
+              aggregatedResults.push(result);
+            }
+          }
+
+          if (aggregatedResults.length > 0) {
+            return aggregatedResults;
+          }
+        }
+      }
+
+      return [];
     } catch (error) {
       console.error('TMDB Search Error:', error);
       return [];
     }
+  }
+
+  private buildSearchCandidates(query: string): string[] {
+    const trimmed = query.replace(/[-\s._]+$/, '').trim();
+    const normalizedSeparators = trimmed.replace(/[._]+/g, ' ').replace(/\s+/g, ' ').trim();
+    const withoutYear = normalizedSeparators.replace(/\b(19|20)\d{2}\b/g, '').replace(/\s+/g, ' ').trim();
+    const candidates = [trimmed, normalizedSeparators, withoutYear]
+      .map((item) => item.trim())
+      .filter(Boolean);
+
+    return Array.from(new Set(candidates));
   }
 
   async getSeasonDetails(showId: string, season: number): Promise<EpisodeData[]> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1780,7 +1780,7 @@ export default function App() {
                       placeholder="输入剧集名称..."
                       className="flex-1 bg-white dark:bg-slate-900 border border-blue-200 dark:border-blue-800 rounded-lg px-4 py-2 text-sm outline-none focus:ring-2 ring-blue-500"
                     />
-                    <button onClick={handleManualSearch} disabled={!manualSeriesName || wizardData.seriesResults?.length === 0} className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded-lg text-xs font-bold transition-all shadow-lg shadow-blue-500/20 disabled:opacity-50 disabled:cursor-not-allowed">
+                    <button onClick={handleManualSearch} disabled={!manualSeriesName.trim()} className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded-lg text-xs font-bold transition-all shadow-lg shadow-blue-500/20 disabled:opacity-50 disabled:cursor-not-allowed">
                       重试
                     </button>
                   </div>


### PR DESCRIPTION
## Summary
- keep the manual retry button enabled whenever the series search input is non-empty
- normalize dotted TMDB search queries like Tales.of.Herding.Gods into space-separated candidates
- fall back across TMDB languages so English aliases can still resolve to the correct show

## Testing
- verified search candidate normalization locally for dotted titles
- ran 
px tsc --noEmit
- did not verify the full TMDB lookup flow against a live update/session in-app

Fixes #32