### PR TITLE
Tech debt: establish ESLint and TypeScript hygiene baseline

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -1,27 +1,31 @@
 /// <reference types="vite-plugin-electron/electron-env" />
+import type { WindowIpcRenderer } from '../shared/ipc';
 
-declare namespace NodeJS {
-  interface ProcessEnv {
-    /**
-     * The built directory structure
-     *
-     * ```tree
-     * ├─┬─┬ dist
-     * │ │ └── index.html
-     * │ │
-     * │ ├─┬ dist-electron
-     * │ │ ├── main.js
-     * │ │ └── preload.js
-     * │
-     * ```
-     */
-    APP_ROOT: string
-    /** /dist/ or /public/ */
-    VITE_PUBLIC: string
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      /**
+       * The built directory structure
+       *
+       * ```tree
+       * ├─┬─┬ dist
+       * │ │ └── index.html
+       * │ │
+       * │ ├─┬ dist-electron
+       * │ │ ├── main.js
+       * │ │ └── preload.js
+       * │
+       * ```
+       */
+      APP_ROOT: string
+      /** /dist/ or /public/ */
+      VITE_PUBLIC: string
+    }
+  }
+
+  interface Window {
+    ipcRenderer: WindowIpcRenderer
   }
 }
 
-// Used in Renderer process, expose in `preload.ts`
-interface Window {
-  ipcRenderer: import('electron').IpcRenderer
-}
+export {};

--- a/electron/interfaces/IMatcher.ts
+++ b/electron/interfaces/IMatcher.ts
@@ -1,12 +1,6 @@
-export interface MatchResult {
-  success: boolean;
-  seriesName?: string;
-  season?: number;
-  episode?: number;
-  year?: string;
-  confidence: number; // 0.0 - 1.0
-  source: 'regex' | 'llm' | 'manual';
-}
+import type { MatchResult } from '../../shared/types';
+
+export type { MatchResult };
 
 export interface IMatcher {
   match(filename: string): Promise<MatchResult>;

--- a/electron/interfaces/IMediaSource.ts
+++ b/electron/interfaces/IMediaSource.ts
@@ -1,24 +1,41 @@
 import { Readable } from 'stream';
+import type { FileItem } from '../../shared/types';
 
-export interface FileItem {
-  name: string;
-  path: string; // Absolute path for local, URL/Path for remote
-  isDir: boolean;
-  size?: number;
-  mtime?: Date;
+export type { FileItem };
+
+export interface BatchRenameItem {
+  src_name: string;
+  new_name: string;
 }
+
+export interface LocalSourceConnectConfig {
+  path: string;
+}
+
+export interface OpenListSourceConnectConfig {
+  url: string;
+  token?: string;
+  proxyUrl?: string;
+}
+
+export type SourceConnectConfig = LocalSourceConnectConfig | OpenListSourceConnectConfig;
 
 export interface IMediaSource {
   id: string; // Unique identifier for this source instance
   name: string; // User-friendly name
   type: 'local' | 'ftp' | 'webdav' | 'openlist';
 
-  connect(config: Record<string, any>): Promise<boolean>;
+  connect(config: SourceConnectConfig): Promise<boolean>;
   disconnect(): Promise<void>;
 
   listDir(path: string): Promise<FileItem[]>;
   getFileStream(path: string): Promise<Readable>;
   rename(oldPath: string, newPath: string): Promise<boolean>;
-  batchRename(srcDir: string, renameObjects: Array<{ src_name: string, new_name: string }>, batchSize?: number, onProgress?: (current: number, total: number) => void): Promise<boolean>;
+  batchRename(
+    srcDir: string,
+    renameObjects: BatchRenameItem[],
+    batchSize?: number,
+    onProgress?: (current: number, total: number) => void,
+  ): Promise<boolean>;
   writeFile(path: string, content: Buffer | string): Promise<boolean>;
 }

--- a/electron/interfaces/IMetadataProvider.ts
+++ b/electron/interfaces/IMetadataProvider.ts
@@ -1,23 +1,6 @@
-export interface SearchResult {
-  id: string; // Provider specific ID (e.g., TMDB ID)
-  title: string;
-  originalTitle?: string;
-  year?: string;
-  poster?: string;
-  overview?: string;
-  provider: string; // 'tmdb', 'tvdb', etc.
-}
+import type { EpisodeData, SearchResult } from '../../shared/types';
 
-export interface EpisodeData {
-  id: string;
-  seasonNumber: number;
-  episodeNumber: number;
-  title: string;
-  overview?: string;
-  airDate?: string;
-  stillPath?: string;
-  runtime?: number;
-}
+export type { EpisodeData, SearchResult };
 
 export interface IMetadataProvider {
   name: string;
@@ -25,4 +8,5 @@ export interface IMetadataProvider {
   getSeasonDetails(showId: string, season: number): Promise<EpisodeData[]>;
   getEpisodeDetails(showId: string, season: number, episode: number): Promise<EpisodeData | null>;
   setDebugLogger?(logger: (message: string) => void): void;
+  setProxy?(proxyUrl: string): void;
 }

--- a/electron/llm/OpenAIClient.ts
+++ b/electron/llm/OpenAIClient.ts
@@ -1,7 +1,8 @@
 import OpenAI from 'openai';
 import { ILLMProvider, LLMConfig } from '../interfaces/ILLMProvider';
 import { ProxyHelper } from '../utils/ProxyHelper';
-import fetch from 'node-fetch';
+import fetch, { type RequestInfo, type RequestInit as NodeFetchRequestInit } from 'node-fetch';
+import { getErrorMessage } from '../utils/errors';
 
 export class OpenAIClient implements ILLMProvider {
   name: string = 'OpenAI';
@@ -14,11 +15,13 @@ export class OpenAIClient implements ILLMProvider {
       apiKey: config.apiKey,
       baseURL: config.baseURL, // Optional: supports generic OpenAI compatible endpoints
       dangerouslyAllowBrowser: false, // We are in Node.js main process
-      fetch: async (url, init) => {
-        return fetch(url as any, {
-          ...init as any,
+      fetch: async (url: string | URL | Request, init?: RequestInit) => {
+        const requestInit = {
+          ...(init ?? {}),
           agent: proxyAgent,
-        }) as unknown as Promise<Response>;
+        } as unknown as NodeFetchRequestInit;
+
+        return fetch(url as unknown as RequestInfo, requestInit) as unknown as Promise<Response>;
       },
     });
     this.model = config.model || 'gpt-3.5-turbo';
@@ -29,8 +32,8 @@ export class OpenAIClient implements ILLMProvider {
     try {
       const response = await this.client.models.list();
       return response.data.map(m => m.id);
-    } catch (e: any) {
-      throw new Error(`Failed to list models: ${e.message}`);
+    } catch (error) {
+      throw new Error(`Failed to list models: ${getErrorMessage(error)}`);
     }
   }
 
@@ -63,7 +66,7 @@ export class OpenAIClient implements ILLMProvider {
     const content = completion.choices[0]?.message?.content || '{}';
     try {
       return JSON.parse(content) as T;
-    } catch (e) {
+    } catch {
       console.error('Failed to parse JSON from LLM:', content);
       throw new Error('Invalid JSON response from LLM');
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -3,6 +3,25 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import ElectronStore from 'electron-store';
 import fs from 'fs-extra';
+import type {
+  ConfigKey,
+  ConfigValueMap,
+  ExplorerListRequest,
+  FetchMetadataRequest,
+  LlmTestRequest,
+  OpenListTestRequest,
+  ScanSelectedRequest,
+  ScanSourceRequest,
+  SmartIdentifyRequest,
+} from '../shared/ipc';
+import type {
+  EpisodeMatchItem,
+  LogLevel,
+  OpenListListResponseData,
+  OpenListResponse,
+  RuleDefinition,
+} from '../shared/types';
+import { getNestedErrorMessage, toErrorResponse } from './utils/errors';
 
 // Core Services
 import { ScannerService } from './services/ScannerService';
@@ -15,6 +34,7 @@ import { OpenAIClient } from './llm/OpenAIClient';
 import { MetadataFactory } from './metadata/factory';
 import { SourceFactory } from './sources/factory';
 import { FetchClient } from './utils/FetchClient';
+import type { IMetadataProvider } from './interfaces/IMetadataProvider';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -32,7 +52,7 @@ let win: BrowserWindow | null = null;
 let store: ElectronStore;
 let scannerService: ScannerService;
 let dbService: DatabaseService;
-let metadataProvider: any;
+let metadataProvider: IMetadataProvider;
 let llmClient: OpenAIClient;
 let llmEngine: LLMEngine;
 let regexEngine: RegexEngine;
@@ -42,7 +62,7 @@ function buildMetadataProvider() {
   const currentProxyUrl = store.get('proxy_url') as string || '';
   const provider = MetadataFactory.create('tmdb', { apiKey: currentTmdbKey });
 
-  if ('setProxy' in provider) (provider as any).setProxy(currentProxyUrl);
+  provider.setProxy?.(currentProxyUrl);
 
   return provider;
 }
@@ -57,39 +77,64 @@ function syncMetadataProvider() {
 }
 
 function registerIpcHandlers() {
-  ipcMain.handle('config:get', (_, key) => store.get(key));
-  ipcMain.handle('config:set', async (_, key, value) => {
+  ipcMain.handle('config:get', (_, key: ConfigKey) => {
+    return store.get(key) as ConfigValueMap[typeof key] | undefined;
+  });
+  ipcMain.handle('config:set', async (_, key: ConfigKey, value: ConfigValueMap[typeof key]) => {
     store.set(key, value);
     if (key === 'proxy_url') {
-      if (win) value ? await win.webContents.session.setProxy({ proxyRules: value as string }) : await win.webContents.session.setProxy({});
-      if (scannerService) scannerService.setProxy(value as string);
+      const proxyValue = value as ConfigValueMap['proxy_url'];
+      if (win) {
+        if (proxyValue) {
+          await win.webContents.session.setProxy({ proxyRules: proxyValue });
+        } else {
+          await win.webContents.session.setProxy({});
+        }
+      }
+      if (scannerService) scannerService.setProxy(proxyValue);
     }
     if (key === 'log_level' && scannerService) {
-      scannerService.setLogLevel(value as any);
+      scannerService.setLogLevel(value as ConfigValueMap['log_level']);
     }
     if ((key === 'tmdb_api_key' || key === 'proxy_url') && scannerService) {
       syncMetadataProvider();
     }
   });
 
-  ipcMain.handle('llm:test', async (_, config) => {
+  ipcMain.handle('llm:test', async (_, config: LlmTestRequest) => {
     try {
       const testClient = new OpenAIClient();
       testClient.configure({ apiKey: config.apiKey, baseURL: config.baseURL, model: 'gpt-3.5-turbo' });
       const models = await testClient.listModels();
       return { success: true, models };
-    } catch (e: any) { return { success: false, error: e.message }; }
+    } catch (error) {
+      return toErrorResponse(error, 'LLM 连接测试失败');
+    }
   });
 
   ipcMain.handle('tmdb:test', async (_, token) => {
     try {
       const proxyUrl = store.get('proxy_url') as string;
       const client = FetchClient.create({ proxyUrl, timeout: 5000 });
-      const response = await client.get('https://api.themoviedb.org/3/authentication', {
+      const response = await client.get<{ success?: boolean; status_message?: string }>('https://api.themoviedb.org/3/authentication', {
         headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' }
       });
       return { success: response.data?.success };
-    } catch (e: any) { return { success: false, error: e.response?.data?.status_message || e.message }; }
+    } catch (error) {
+      return {
+        success: false,
+        error: getNestedErrorMessage(
+          error,
+          (value) => {
+            const data = value.response?.data;
+            return typeof data === 'object' && data !== null && 'status_message' in data
+              ? String((data as { status_message?: string }).status_message ?? '')
+              : undefined;
+          },
+          'TMDB 连接测试失败',
+        ),
+      };
+    }
   });
 
   ipcMain.handle('proxy:test', async () => {
@@ -98,22 +143,38 @@ function registerIpcHandlers() {
       const client = FetchClient.create({ proxyUrl, timeout: 5000 });
       await client.get('https://www.gstatic.com/generate_204');
       return { success: true };
-    } catch (e: any) { return { success: false, error: e.message }; }
+    } catch (error) {
+      return toErrorResponse(error, '代理连接测试失败');
+    }
   });
 
-  ipcMain.handle('openlist:test', async (_, config) => {
+  ipcMain.handle('openlist:test', async (_, config: OpenListTestRequest) => {
     try {
       const proxyUrl = store.get('proxy_url') as string;
       const client = FetchClient.create({ proxyUrl, timeout: 5000 });
       const baseURL = config.url.replace(/\/$/, '');
-      const response = await client.get(`${baseURL}/api/me`, {
+      const response = await client.get<OpenListResponse>(`${baseURL}/api/me`, {
         headers: { 'Authorization': config.token }
       });
       return { success: response.status === 200 && response.data?.code === 200 };
-    } catch (e: any) { return { success: false, error: e.response?.data?.message || e.message }; }
+    } catch (error) {
+      return {
+        success: false,
+        error: getNestedErrorMessage(
+          error,
+          (value) => {
+            const data = value.response?.data;
+            return typeof data === 'object' && data !== null && 'message' in data
+              ? String((data as { message?: string }).message ?? '')
+              : undefined;
+          },
+          'OpenList 连接测试失败',
+        ),
+      };
+    }
   });
 
-  ipcMain.handle('explorer:list', async (_, { type, path: targetPath, config }) => {
+  ipcMain.handle('explorer:list', async (_, { type, path: targetPath, config }: ExplorerListRequest) => {
     try {
       if (type === 'local') {
         const fullPath = targetPath || config.localPath;
@@ -133,19 +194,33 @@ function registerIpcHandlers() {
         return { success: true, data, currentPath: fullPath };
       }
       else if (type === 'openlist') {
+        if (!config.openListUrl) {
+          return { success: false, error: 'OpenList 地址未配置' };
+        }
         const proxyUrl = store.get('proxy_url') as string;
         const client = FetchClient.create({ proxyUrl });
         const baseURL = config.openListUrl.replace(/\/$/, '');
         const reqPath = targetPath || '/';
-        const response = await client.post(`${baseURL}/api/fs/list`, { path: reqPath, password: "", page: 1, per_page: 0, refresh: true }, { headers: { 'Authorization': config.openListToken } });
+        const response = await client.post<OpenListResponse<OpenListListResponseData>>(
+          `${baseURL}/api/fs/list`,
+          { path: reqPath, password: "", page: 1, per_page: 0, refresh: true },
+          { headers: { 'Authorization': config.openListToken ?? '' } },
+        );
         if (response.data.code !== 200) return { success: false, error: response.data.message };
-        const content = response.data.data.content || [];
-        const items = content.map((item: any) => ({ name: item.name, path: path.posix.join(reqPath, item.name), isDir: item.is_dir, size: item.size }));
-        items.sort((a: any, b: any) => (a.isDir === b.isDir ? a.name.localeCompare(b.name) : a.isDir ? -1 : 1));
+        const content = response.data.data?.content || [];
+        const items = content.map((item) => ({
+          name: item.name,
+          path: path.posix.join(reqPath, item.name),
+          isDir: item.is_dir,
+          size: item.size,
+        }));
+        items.sort((a, b) => (a.isDir === b.isDir ? a.name.localeCompare(b.name) : a.isDir ? -1 : 1));
         return { success: true, data: items, currentPath: reqPath };
       }
       return { success: false, error: '未知的数据源类型' };
-    } catch (e: any) { return { success: false, error: e.message }; }
+    } catch (error) {
+      return toErrorResponse(error, '目录加载失败');
+    }
   });
 
   ipcMain.handle('dialog:openDirectory', async () => {
@@ -158,7 +233,7 @@ function registerIpcHandlers() {
   ipcMain.on('window:maximize', () => win?.isMaximized() ? win.unmaximize() : win?.maximize());
   ipcMain.on('window:close', () => win?.close());
 
-  ipcMain.handle('scanner:start', async (_, sourceConfig) => {
+  ipcMain.handle('scanner:start', async (_, sourceConfig: ScanSourceRequest) => {
     try {
       const source = SourceFactory.create(sourceConfig.type, sourceConfig.id, 'Source');
       const connectConfig = sourceConfig.type === 'local'
@@ -180,12 +255,16 @@ function registerIpcHandlers() {
       scannerService.setOpenListBatchSize(parseInt(batchSize, 10));
 
       const videoExtensions = store.get('video_extensions') as string || 'mkv,mp4,avi,mov,iso,rmvb';
-      scannerService.scanSource(source, sourceConfig.path, videoExtensions).catch(err => console.error('Scan Error:', err));
+      scannerService.scanSource(source, sourceConfig.path, videoExtensions).catch((error: unknown) => {
+        console.error('Scan Error:', error);
+      });
       return { success: true };
-    } catch (e: any) { return { success: false, error: e.message }; }
+    } catch (error) {
+      return toErrorResponse(error, '扫描启动失败');
+    }
   });
 
-  ipcMain.handle('scanner:scan-selected', async (_, sourceConfig) => {
+  ipcMain.handle('scanner:scan-selected', async (_, sourceConfig: ScanSelectedRequest) => {
     try {
       const source = SourceFactory.create(sourceConfig.type, sourceConfig.id, 'Source');
       const connectConfig = sourceConfig.type === 'local'
@@ -207,12 +286,16 @@ function registerIpcHandlers() {
       scannerService.setOpenListBatchSize(parseInt(batchSize, 10));
 
       const videoExtensions = store.get('video_extensions') as string || 'mkv,mp4,avi,mov,iso,rmvb';
-      scannerService.scanSelectedFiles(source, sourceConfig.paths, videoExtensions).catch(err => console.error('Scan Selected Error:', err));
+      scannerService.scanSelectedFiles(source, sourceConfig.paths, videoExtensions).catch((error: unknown) => {
+        console.error('Scan Selected Error:', error);
+      });
       return { success: true };
-    } catch (e: any) { return { success: false, error: e.message }; }
+    } catch (error) {
+      return toErrorResponse(error, '选中文件扫描启动失败');
+    }
   });
 
-  ipcMain.handle('scanner:identify-single', async (_, sourceConfig) => {
+  ipcMain.handle('scanner:identify-single', async (_, sourceConfig: ScanSourceRequest) => {
     try {
       const source = SourceFactory.create(sourceConfig.type, sourceConfig.id, 'Source');
       const connectConfig = sourceConfig.type === 'local'
@@ -234,9 +317,13 @@ function registerIpcHandlers() {
       scannerService.setOpenListBatchSize(parseInt(batchSize, 10));
 
       const videoExtensions = store.get('video_extensions') as string || 'mkv,mp4,avi,mov,iso,rmvb';
-      scannerService.identifySingleFile(source, sourceConfig.path, videoExtensions).catch(err => console.error('Identify Error:', err));
+      scannerService.identifySingleFile(source, sourceConfig.path, videoExtensions).catch((error: unknown) => {
+        console.error('Identify Error:', error);
+      });
       return { success: true };
-    } catch (e: any) { return { success: false, error: e.message }; }
+    } catch (error) {
+      return toErrorResponse(error, '单文件识别启动失败');
+    }
   });
 
   ipcMain.handle('media:getAll', () => dbService.getAllMedia());
@@ -246,12 +333,12 @@ function registerIpcHandlers() {
 
   ipcMain.handle('app:getVersion', () => app.getVersion());
 
-  ipcMain.handle('scanner:fetch-metadata', async (event, { matches, seriesId }) => {
+  ipcMain.handle('scanner:fetch-metadata', async (event, { matches, seriesId }: FetchMetadataRequest) => {
     try {
       const total = matches.length;
       console.log(`[元数据获取] 开始获取 ${total} 个文件的元数据，seriesId: ${seriesId}`);
 
-      const updatedMatches = [];
+      const updatedMatches: EpisodeMatchItem[] = [];
       let completed = 0;
       const concurrencyLimit = 10; // 并发限制为10个请求
 
@@ -259,7 +346,7 @@ function registerIpcHandlers() {
       event.sender.send('metadata-progress', { current: 0, total });
 
       // 批量处理函数
-      const processBatch = async (items: any[]) => {
+      const processBatch = async (items: EpisodeMatchItem[]) => {
         const promises = items.map(async (item) => {
           try {
             const metadata = await metadataProvider.getEpisodeDetails(
@@ -279,8 +366,8 @@ function registerIpcHandlers() {
               },
               metadata: metadata || undefined
             };
-          } catch (e) {
-            console.error(`Failed to fetch metadata for ${item.file.name}:`, e);
+          } catch (error) {
+            console.error(`Failed to fetch metadata for ${item.file.name}:`, error);
             completed++;
             event.sender.send('metadata-progress', { current: completed, total });
             return item;
@@ -302,15 +389,15 @@ function registerIpcHandlers() {
 
       console.log(`[元数据获取] 完成！共处理 ${total} 个文件`);
       return { success: true, matches: updatedMatches };
-    } catch (e: any) {
-      console.error('[元数据获取] 错误:', e);
-      return { success: false, error: e.message };
+    } catch (error) {
+      console.error('[元数据获取] 错误:', error);
+      return toErrorResponse(error, '元数据获取失败');
     }
   });
 
-  ipcMain.handle('scanner:smart-identify', async (_, { unmatchedFiles }) => {
+  ipcMain.handle('scanner:smart-identify', async (_, { unmatchedFiles }: SmartIdentifyRequest) => {
     try {
-      const results = [];
+      const results: EpisodeMatchItem[] = [];
 
       for (const fileData of unmatchedFiles) {
         try {
@@ -326,8 +413,8 @@ function registerIpcHandlers() {
               source: 'llm_failed'
             }
           });
-        } catch (e) {
-          console.error(`LLM识别失败: ${fileData.file.name}:`, e);
+        } catch (error) {
+          console.error(`LLM识别失败: ${fileData.file.name}:`, error);
           results.push({
             ...fileData,
             match: { success: false, source: 'llm_error' }
@@ -336,8 +423,8 @@ function registerIpcHandlers() {
       }
 
       return { success: true, results };
-    } catch (e: any) {
-      return { success: false, error: e.message };
+    } catch (error) {
+      return toErrorResponse(error, '智能识别失败');
     }
   });
 
@@ -345,21 +432,21 @@ function registerIpcHandlers() {
     const defaultPath = path.join(process.env.DIST_ELECTRON || '', 'resources/default_rules.json');
     const userPath = path.join(app.getPath('userData'), 'custom_rules.json');
 
-    let rules: any[] = [];
+    let rules: RuleDefinition[] = [];
     if (await fs.pathExists(defaultPath)) rules = await fs.readJSON(defaultPath);
 
     if (await fs.pathExists(userPath)) {
-      const userRules = await fs.readJSON(userPath);
+      const userRules = await fs.readJSON(userPath) as RuleDefinition[];
       // Deduplicate by ID: User rules take precedence
-      const ruleMap = new Map();
+      const ruleMap = new Map<string, RuleDefinition>();
       rules.forEach(r => ruleMap.set(r.id, r));
-      userRules.forEach((r: any) => ruleMap.set(r.id, r));
+      userRules.forEach((rule) => ruleMap.set(rule.id, rule));
       rules = Array.from(ruleMap.values());
     }
     return rules;
   });
 
-  ipcMain.handle('rules:save', async (_, rules) => {
+  ipcMain.handle('rules:save', async (_, rules: RuleDefinition[]) => {
     const userPath = path.join(app.getPath('userData'), 'custom_rules.json');
     await fs.writeJSON(userPath, rules, { spaces: 2 });
     return { success: true };
@@ -427,8 +514,8 @@ app.whenReady().then(() => {
 
     scannerService = new ScannerService(regexEngine, llmEngine, metadataProvider, dbService);
 
-    const savedLogLevel = store.get('log_level') as string || 'info';
-    scannerService.setLogLevel(savedLogLevel as any);
+    const savedLogLevel = store.get('log_level') as LogLevel || 'info';
+    scannerService.setLogLevel(savedLogLevel);
 
     syncMetadataProvider();
 

--- a/electron/matchers/LLMEngine.ts
+++ b/electron/matchers/LLMEngine.ts
@@ -1,6 +1,7 @@
 import { IMatcher, MatchResult } from '../interfaces/IMatcher';
 import { ILLMProvider } from '../interfaces/ILLMProvider';
 import path from 'path';
+import type { EpisodeData } from '../interfaces/IMetadataProvider';
 
 export class LLMEngine implements IMatcher {
   private llm: ILLMProvider;
@@ -15,14 +16,14 @@ export class LLMEngine implements IMatcher {
     this.debugLogger = logger;
   }
 
-  private logDebug(msg: string, data?: any) {
+  private logDebug(msg: string, data?: unknown) {
     if (this.debugLogger) {
       const dataStr = data ? `\nData: ${JSON.stringify(data, null, 2)}` : '';
       this.debugLogger(`${msg}${dataStr}`);
     }
   }
 
-  async matchEpisodeFromList(filename: string, episodeList: any[]): Promise<number | null> {
+  async matchEpisodeFromList(filename: string, episodeList: EpisodeData[]): Promise<number | null> {
     const listStr = episodeList.map(e => `E${e.episodeNumber}: ${e.title} (${e.overview?.substring(0, 50)}...)`).join('\n');
 
     const prompt = `

--- a/electron/metadata/TMDBProvider.ts
+++ b/electron/metadata/TMDBProvider.ts
@@ -1,6 +1,11 @@
 import { FetchClient } from '../utils/FetchClient';
 import { IMetadataProvider, SearchResult, EpisodeData } from '../interfaces/IMetadataProvider';
 import { ProxyHelper } from '../utils/ProxyHelper';
+import type {
+  TmdbEpisodeItem,
+  TmdbSearchResponse,
+  TmdbSeasonResponse,
+} from '../../shared/types';
 
 export class TMDBProvider implements IMetadataProvider {
   name: string = 'TMDB';
@@ -25,7 +30,6 @@ export class TMDBProvider implements IMetadataProvider {
     // Add request interceptor for logging
     // Add request interceptor for logging
     this.api.interceptors.request.use(config => {
-      // @ts-ignore
       this.logDebug(`Request: ${config.method?.toUpperCase()} ${config.url}`, config.params);
       return config;
     });
@@ -34,7 +38,11 @@ export class TMDBProvider implements IMetadataProvider {
       this.logDebug(`Response: ${response.status} ${response.config.url}`, { data: response.data });
       return response;
     }, error => {
-      this.logDebug(`Response Error: ${error.message}`, error.response?.data);
+      if (FetchClient.isFetchError(error)) {
+        this.logDebug(`Response Error: ${error.message}`, error.response?.data);
+      } else {
+        this.logDebug('Response Error', error);
+      }
       throw error;
     });
   }
@@ -55,7 +63,7 @@ export class TMDBProvider implements IMetadataProvider {
     }
   }
 
-  private logDebug(msg: string, data?: any) {
+  private logDebug(msg: string, data?: unknown) {
     if (this.debugLogger) {
       const dataStr = data ? `\nData: ${JSON.stringify(data, null, 2)}` : '';
       this.debugLogger(`${msg}${dataStr}`);
@@ -69,11 +77,11 @@ export class TMDBProvider implements IMetadataProvider {
 
       for (const language of this.fallbackLanguages) {
         for (const candidate of this.buildSearchCandidates(query)) {
-          const response = await this.api.get('/search/tv', {
+          const response = await this.api.get<TmdbSearchResponse>('/search/tv', {
             params: { query: candidate, language },
           });
 
-          const results = response.data.results.map((item: any) => ({
+          const results = response.data.results.map((item) => ({
             id: item.id.toString(),
             title: item.name,
             originalTitle: item.original_name,
@@ -116,8 +124,8 @@ export class TMDBProvider implements IMetadataProvider {
 
   async getSeasonDetails(showId: string, season: number): Promise<EpisodeData[]> {
     try {
-      const response = await this.api.get(`/tv/${showId}/season/${season}`);
-      return response.data.episodes.map((data: any) => ({
+      const response = await this.api.get<TmdbSeasonResponse>(`/tv/${showId}/season/${season}`);
+      return response.data.episodes.map((data: TmdbEpisodeItem) => ({
         id: data.id.toString(),
         seasonNumber: data.season_number,
         episodeNumber: data.episode_number,
@@ -135,7 +143,7 @@ export class TMDBProvider implements IMetadataProvider {
 
   async getEpisodeDetails(showId: string, season: number, episode: number): Promise<EpisodeData | null> {
     try {
-      const response = await this.api.get(`/tv/${showId}/season/${season}/episode/${episode}`, {
+      const response = await this.api.get<TmdbEpisodeItem>(`/tv/${showId}/season/${season}/episode/${episode}`, {
         params: {
           append_to_response: 'credits,images' // Optional: add more details for the "detailed view"
         }
@@ -152,7 +160,7 @@ export class TMDBProvider implements IMetadataProvider {
         stillPath: data.still_path ? `${this.imageBaseUrl}${data.still_path}` : undefined,
         runtime: data.runtime,
       };
-    } catch (error: any) {
+    } catch (error) {
       // 404 is expected if episode doesn't exist
       // 404 is expected if episode doesn't exist
       if (FetchClient.isFetchError(error) && error.response?.status === 404) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,12 +1,29 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import type { RendererEventChannel, RendererEventPayloadMap, WindowIpcRenderer } from '../shared/ipc';
 
-contextBridge.exposeInMainWorld('ipcRenderer', {
-  invoke: (channel: string, ...args: any[]) => ipcRenderer.invoke(channel, ...args),
-  on: (channel: string, func: (...args: any[]) => void) => {
-    const subscription = (_event: any, ...args: any[]) => func(...args);
+const api = {
+  invoke: (channel: string, ...args: unknown[]) =>
+    ipcRenderer.invoke(channel, ...args) as Promise<unknown>,
+  on: <K extends RendererEventChannel>(
+    channel: K,
+    func: RendererEventPayloadMap[K] extends undefined
+      ? () => void
+      : (payload: RendererEventPayloadMap[K]) => void,
+  ) => {
+    const subscription = (_event: IpcRendererEvent, payload?: RendererEventPayloadMap[K]) => {
+      if (payload === undefined) {
+        (func as () => void)();
+        return;
+      }
+
+      (func as (value: RendererEventPayloadMap[K]) => void)(payload);
+    };
     ipcRenderer.on(channel, subscription);
     return () => ipcRenderer.removeListener(channel, subscription);
   },
-  off: (channel: string, func: (...args: any[]) => void) => ipcRenderer.removeListener(channel, func),
-  send: (channel: string, ...args: any[]) => ipcRenderer.send(channel, ...args),
-});
+  send: (channel: string, ...args: unknown[]) => {
+    ipcRenderer.send(channel, ...args);
+  },
+} as WindowIpcRenderer;
+
+contextBridge.exposeInMainWorld('ipcRenderer', api);

--- a/electron/services/DatabaseService.ts
+++ b/electron/services/DatabaseService.ts
@@ -80,6 +80,10 @@ export interface ScrapedMedia {
   scrapedAt: string;
 }
 
+interface TableInfoRow {
+  name: string;
+}
+
 export class DatabaseService {
   private db: BetterSqliteDatabase;
 
@@ -122,7 +126,7 @@ export class DatabaseService {
     `);
 
     // Migration for existing databases
-    const tableInfo = this.db.prepare("PRAGMA table_info(scraped_media)").all() as any[];
+    const tableInfo = this.db.prepare("PRAGMA table_info(scraped_media)").all() as TableInfoRow[];
     const columns = tableInfo.map(c => c.name);
     
     if (!columns.includes('air_date')) {

--- a/electron/services/ScannerService.ts
+++ b/electron/services/ScannerService.ts
@@ -1,12 +1,31 @@
-import { IMediaSource } from '../interfaces/IMediaSource';
+import { IMediaSource, type BatchRenameItem, type FileItem } from '../interfaces/IMediaSource';
 import { RegexEngine } from '../matchers/RegexEngine';
 import { LLMEngine } from '../matchers/LLMEngine';
-import { IMetadataProvider } from '../interfaces/IMetadataProvider';
+import { IMetadataProvider, type EpisodeData, type SearchResult } from '../interfaces/IMetadataProvider';
 import { DatabaseService } from './DatabaseService';
 import { BrowserWindow, ipcMain } from 'electron';
 import path from 'path';
-import fetch from 'node-fetch';
+import fetch, { type RequestInit } from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import type {
+  ScannerConfirmResponsePayload,
+  ScannerEpisodesConfirmResponsePayload,
+} from '../../shared/ipc';
+import type {
+  BatchOptions,
+  EpisodeConfirmationPayload,
+  EpisodeMatchItem,
+  LogLevel,
+} from '../../shared/types';
+import { getErrorMessage } from '../utils/errors';
+
+type CachedSeriesInfo = { id: string; poster?: string };
+type UserConfirmationResult = {
+  id: string;
+  poster?: string;
+  newName?: string;
+  confirmedName?: string;
+};
 
 export class ScannerService {
   private regexEngine: RegexEngine;
@@ -16,10 +35,10 @@ export class ScannerService {
   private mainWindow: BrowserWindow | null = null;
   private _isScanning: boolean = false;
 
-  private showMetadataCache: Map<string, { id: string, poster?: string }> = new Map();
-  private logLevel: 'info' | 'warn' | 'error' | 'debug' = 'info';
-  private proxyUrl: string = '';
-  private openListBatchSize: number = 20;
+  private showMetadataCache: Map<string, CachedSeriesInfo> = new Map();
+  private logLevel: LogLevel = 'info';
+  private proxyUrl = '';
+  private openListBatchSize = 20;
 
   constructor(
     regexEngine: RegexEngine,
@@ -43,40 +62,31 @@ export class ScannerService {
 
   setMetadataProvider(provider: IMetadataProvider) {
     this.metadataProvider = provider;
-    if (this.logLevel === 'debug' && typeof (this.metadataProvider as any).setDebugLogger === 'function') {
-      (this.metadataProvider as any).setDebugLogger((msg: string) => this.debug(`[Metadata] ${msg} `));
-    }
+    this.bindDebugLoggers();
   }
 
-  setLogLevel(level: 'info' | 'warn' | 'error' | 'debug') {
+  setLogLevel(level: LogLevel) {
     this.logLevel = level;
-    // Update dependencies if they support logging injection
-    if (this.logLevel === 'debug') {
-      if (typeof (this.metadataProvider as any).setDebugLogger === 'function') {
-        (this.metadataProvider as any).setDebugLogger((msg: string) => this.debug(`[Metadata] ${msg} `));
-      }
-      if (typeof (this.llmEngine as any).setDebugLogger === 'function') {
-        (this.llmEngine as any).setDebugLogger((msg: string) => this.debug(`[LLM] ${msg} `));
-      }
-    } else {
-      // Optional: Clear loggers if we want to stop receiving them, 
-      // but simpler to just filter them out in this.debug()
-    }
+    this.bindDebugLoggers();
   }
 
   setProxy(proxyUrl: string) {
     this.proxyUrl = proxyUrl;
-    // Also update metadata provider if it supports it
-    if (this.metadataProvider && typeof (this.metadataProvider as any).setProxy === 'function') {
-      (this.metadataProvider as any).setProxy(proxyUrl);
-    }
+    this.metadataProvider.setProxy?.(proxyUrl);
   }
 
   setOpenListBatchSize(size: number) {
     this.openListBatchSize = size > 0 ? size : 20;
   }
 
-  private log(message: string, type: 'info' | 'error' | 'success' | 'warn' | 'debug' = 'info') {
+  private bindDebugLoggers() {
+    if (this.logLevel === 'debug') {
+      this.metadataProvider.setDebugLogger?.((msg) => this.debug(`[Metadata] ${msg} `));
+      this.llmEngine.setDebugLogger((msg) => this.debug(`[LLM] ${msg} `));
+    }
+  }
+
+  private log(message: string, type: LogLevel | 'success' = 'info') {
     // Level Priority: debug < info < warn/success < error
     const levels = { debug: 0, info: 1, success: 2, warn: 2, error: 3 };
     const currentLevelScore = levels[this.logLevel] ?? 1;
@@ -88,19 +98,22 @@ export class ScannerService {
     }
   }
 
-  public debug(message: string, data?: any) {
+  public debug(message: string, data?: unknown) {
     if (this.logLevel !== 'debug') return;
     const suffix = data ? `\nData: ${JSON.stringify(data, null, 2)} ` : '';
     this.log(`${message}${suffix} `, 'debug');
   }
 
-  private async requestUserConfirmation(detectedName: string, results: any[]): Promise<{ id: string, poster?: string, newName?: string, confirmedName?: string } | null> {
+  private async requestUserConfirmation(
+    detectedName: string,
+    results: SearchResult[],
+  ): Promise<UserConfirmationResult | null> {
     if (!this.mainWindow) return null;
     return new Promise((resolve) => {
       setTimeout(() => {
         this.mainWindow?.webContents.send('scanner-require-confirmation', { detectedName, results });
       }, 200);
-      ipcMain.once('scanner-confirm-response', (_: any, response: { seriesId: string | null, newName?: string, seriesName?: string }) => {
+      ipcMain.once('scanner-confirm-response', (_event, response: ScannerConfirmResponsePayload) => {
         // If user provided a new name to search
         if (response.newName) {
           resolve({ id: '', newName: response.newName });
@@ -111,17 +124,21 @@ export class ScannerService {
         resolve(selected ? {
           id: selected.id,
           poster: selected.poster,
-          confirmedName: response.seriesName || selected.name // 使用前端传来的名称或从结果中获取
+          confirmedName: response.seriesName || selected.title
         } : null);
       });
     });
   }
 
-  private async requestEpisodesConfirmation(seriesName: string, matches: any[]): Promise<{ confirmed: boolean, options: any, selectedIndices: number[], updatedMatches?: any[] }> {
-    if (!this.mainWindow) return { confirmed: false, options: {}, selectedIndices: [] };
+  private async requestEpisodesConfirmation(
+    seriesName: string,
+    matches: EpisodeMatchItem[],
+  ): Promise<ScannerEpisodesConfirmResponsePayload> {
+    if (!this.mainWindow) return { confirmed: false, selectedIndices: [] };
     return new Promise((resolve) => {
-      this.mainWindow?.webContents.send('scanner-require-episodes-confirmation', { seriesName, matches });
-      ipcMain.once('scanner-episodes-confirm-response', (_: any, response: { confirmed: boolean, options: any, selectedIndices: number[], updatedMatches?: any[] }) => {
+      const payload: EpisodeConfirmationPayload = { seriesName, matches };
+      this.mainWindow?.webContents.send('scanner-require-episodes-confirmation', payload);
+      ipcMain.once('scanner-episodes-confirm-response', (_event, response: ScannerEpisodesConfirmResponsePayload) => {
         resolve(response);
       });
     });
@@ -129,11 +146,11 @@ export class ScannerService {
 
   private async downloadImage(url: string): Promise<Buffer | null> {
     try {
-      const config: any = {};
+      const config: RequestInit = {};
       if (this.proxyUrl) {
         try {
           config.agent = new HttpsProxyAgent(this.proxyUrl);
-        } catch (e) {
+        } catch {
           // ignore invalid proxy
         }
       }
@@ -142,11 +159,13 @@ export class ScannerService {
         return Buffer.from(await response.arrayBuffer());
       }
       return null;
-    } catch (e) { return null; }
+    } catch {
+      return null;
+    }
   }
 
-  private async recursiveList(source: IMediaSource, dirPath: string): Promise<any[]> {
-    let results: any[] = [];
+  private async recursiveList(source: IMediaSource, dirPath: string): Promise<FileItem[]> {
+    let results: FileItem[] = [];
     try {
       const items = await source.listDir(dirPath);
       for (const item of items) {
@@ -156,7 +175,9 @@ export class ScannerService {
           results = results.concat(subItems);
         }
       }
-    } catch (e: any) { this.log(`Error listing dir ${dirPath}: ${e.message} `, 'error'); }
+    } catch (error) {
+      this.log(`Error listing dir ${dirPath}: ${getErrorMessage(error)} `, 'error');
+    }
     return results;
   }
 
@@ -171,7 +192,7 @@ export class ScannerService {
       const allFiles = await source.listDir(dirPath);
 
       const extPattern = videoExtensions.split(',').map(e => e.trim()).filter(e => e).join('|');
-      const videoRegex = new RegExp(`\.(${extPattern})$`, 'i');
+      const videoRegex = new RegExp(`\\.(${extPattern})$`, 'i');
       const videoFiles = allFiles.filter(f => !f.isDir && videoRegex.test(f.name));
 
       this.log(`上下文: 找到 ${videoFiles.length} 个同级视频文件。`);
@@ -188,7 +209,7 @@ export class ScannerService {
       this.log(`LLM 识别成功: ${resolveResult.seriesName} (第 ${resolveResult.season} 季)`, 'success');
 
       // Construct items list similar to scanSource
-      const items: any[] = [];
+      const items: EpisodeMatchItem[] = [];
       for (const file of videoFiles) {
         // Only process the target file
         if (file.name !== pathApi.basename(targetPath)) continue;
@@ -210,15 +231,20 @@ export class ScannerService {
       // Reuse the processing logic
       await this.processSeriesGroup(source, resolveResult.seriesName, items);
 
-    } catch (e: any) {
-      this.log(`识别失败: ${e.message} `, 'error');
+    } catch (error) {
+      this.log(`识别失败: ${getErrorMessage(error)} `, 'error');
     } finally {
       this._isScanning = false;
       this.mainWindow?.webContents.send('scanner-finished');
     }
   }
 
-  private async processSeriesGroup(source: IMediaSource, seriesName: string, items: any[], skipMetadata: boolean = false) {
+  private async processSeriesGroup(
+    source: IMediaSource,
+    seriesName: string,
+    items: EpisodeMatchItem[],
+    skipMetadata = false,
+  ) {
     let seriesInfo = this.showMetadataCache.get(seriesName);
     let currentSearchName = seriesName;
     let confirmedSeriesName = seriesName; // 保存用户确认的剧集名称
@@ -258,10 +284,10 @@ export class ScannerService {
 
     const tmdbId = seriesInfo.id;
 
-    let matchedItems;
+    let matchedItems: EpisodeMatchItem[];
     if (skipMetadata) {
       // 跳过元数据获取，但仍需获取季总集数用于文件名格式
-      const seasonsInGroup = new Set<number>(items.map(i => i.match.season ?? 1));
+      const seasonsInGroup = new Set<number>(items.map((item) => item.match.season ?? 1));
       const seasonEpisodeCounts: Map<number, number> = new Map();
 
       for (const seasonNum of seasonsInGroup) {
@@ -284,8 +310,8 @@ export class ScannerService {
       }));
     } else {
       // 原有逻辑：获取元数据
-      const seasonsInGroup = new Set<number>(items.map(i => i.match.season ?? 1));
-      const seasonCache: Map<number, any[]> = new Map();
+      const seasonsInGroup = new Set<number>(items.map((item) => item.match.season ?? 1));
+      const seasonCache: Map<number, EpisodeData[]> = new Map();
       const seasonEpisodeCounts: Map<number, number> = new Map();  // 保存每季的总集数
 
       for (const seasonNum of seasonsInGroup) {
@@ -300,13 +326,13 @@ export class ScannerService {
         const currentSeason = item.match.season ?? 1;
         const seasonData = seasonCache.get(currentSeason) || [];
         const totalEpisodes = seasonEpisodeCounts.get(currentSeason) || 0;  // 获取总集数
-        let epData = seasonData.find(e => e.episodeNumber === item.match.episode);
+        let epData = seasonData.find((episode) => episode.episodeNumber === item.match.episode);
 
         // Fuzzy Match if needed (though LLM context should have done it)
         if (!epData && seasonData.length > 0) {
           const bestEpisodeNumber = await this.llmEngine.matchEpisodeFromList(item.file.name, seasonData);
           if (bestEpisodeNumber !== null) {
-            epData = seasonData.find(e => e.episodeNumber === bestEpisodeNumber);
+            epData = seasonData.find((episode) => episode.episodeNumber === bestEpisodeNumber);
             if (epData) item.match.episode = bestEpisodeNumber;
           }
         }
@@ -322,14 +348,29 @@ export class ScannerService {
       }
     }
 
-    const { confirmed, options, selectedIndices, updatedMatches } = await this.requestEpisodesConfirmation(confirmedSeriesName, matchedItems);
+    const { confirmed, options, selectedIndices, updatedMatches } =
+      await this.requestEpisodesConfirmation(confirmedSeriesName, matchedItems);
     if (confirmed && selectedIndices.length > 0) {
-      await this.executeBatch(source, confirmedSeriesName, updatedMatches || matchedItems, selectedIndices, options, seriesInfo);
+      await this.executeBatch(
+        source,
+        confirmedSeriesName,
+        updatedMatches || matchedItems,
+        selectedIndices,
+        options ?? { rename: true, writeNfo: true, writePoster: true, writeStill: true },
+        seriesInfo,
+      );
     }
   }
 
-  private async executeBatch(source: IMediaSource, seriesName: string, matchedItems: any[], selectedIndices: number[], options: any, seriesInfo: any) {
-    const renameObjects: any[] = [];
+  private async executeBatch(
+    source: IMediaSource,
+    seriesName: string,
+    matchedItems: EpisodeMatchItem[],
+    selectedIndices: number[],
+    options: BatchOptions,
+    seriesInfo: CachedSeriesInfo,
+  ) {
+    const renameObjects: BatchRenameItem[] = [];
     const itemsToProcess = selectedIndices.map(idx => matchedItems[idx]);
     const totalSteps = itemsToProcess.length * ((options.writeNfo ? 1 : 0) + (options.writeStill ? 1 : 0)) + (options.writePoster ? 1 : 0) + (options.rename ? 1 : 0);
     let currentStep = 0;
@@ -441,7 +482,7 @@ export class ScannerService {
     this.log(`开始扫描 ${selectedPaths.length} 个选定文件...`);
 
     try {
-      const fileItems: any[] = [];
+      const fileItems: FileItem[] = [];
       const pathsByDir = new Map<string, Set<string>>();
       const pathApi = source.type === 'local' ? path : path.posix;
 
@@ -460,7 +501,7 @@ export class ScannerService {
               fileItems.push(item);
             }
           }
-        } catch (e) {
+        } catch {
           this.log(`无法访问目录 ${dir}`, 'warn');
         }
       }
@@ -472,8 +513,8 @@ export class ScannerService {
 
       await this.processFileList(source, fileItems, videoExtensions, true);
 
-    } catch (e: any) {
-      this.log(`扫描失败: ${e.message}`, 'error');
+    } catch (error) {
+      this.log(`扫描失败: ${getErrorMessage(error)}`, 'error');
     } finally {
       this._isScanning = false;
       this.mainWindow?.webContents.send('scanner-finished');
@@ -492,18 +533,26 @@ export class ScannerService {
       this.log('正在遍历目录结构...');
       const allFiles = await this.recursiveList(source, startPath);
       await this.processFileList(source, allFiles, videoExtensions);
-    } catch (error: any) { this.log(`扫描失败: ${error.message}`, 'error'); }
+    } catch (error) {
+      this.log(`扫描失败: ${getErrorMessage(error)}`, 'error');
+    }
     finally { this._isScanning = false; this.log('扫描完成'); this.mainWindow?.webContents.send('scanner-finished'); }
   }
 
-  private async processFileList(source: IMediaSource, allFiles: any[], videoExtensions: string, skipMetadata: boolean = false, skipLLM: boolean = true) {
+  private async processFileList(
+    source: IMediaSource,
+    allFiles: FileItem[],
+    videoExtensions: string,
+    skipMetadata = false,
+    skipLLM = true,
+  ) {
     const extPattern = videoExtensions.split(',').map(e => e.trim()).filter(e => e).join('|');
-    const videoRegex = new RegExp(`\.(${extPattern})$`, 'i');
+    const videoRegex = new RegExp(`\\.(${extPattern})$`, 'i');
     const videoFiles = allFiles.filter(f => !f.isDir && videoRegex.test(f.name));
     this.log(`发现 ${videoFiles.length} 个视频文件。`);
 
-    const groups: Map<string, any[]> = new Map();
-    const dirGroups: Map<string, any[]> = new Map();
+    const groups: Map<string, EpisodeMatchItem[]> = new Map();
+    const dirGroups: Map<string, FileItem[]> = new Map();
 
     // First pass: Group by directory
     for (const file of videoFiles) {
@@ -514,8 +563,8 @@ export class ScannerService {
 
     // Second pass: Process each directory group
     for (const [dir, filesInDir] of dirGroups.entries()) {
-      const dirResults: Array<{ file: any, match: any }> = [];
-      const unmatchedFiles: any[] = [];
+      const dirResults: EpisodeMatchItem[] = [];
+      const unmatchedFiles: FileItem[] = [];
 
       for (const file of filesInDir) {
         const match = await this.regexEngine.match(file.name);

--- a/electron/services/UpdateService.ts
+++ b/electron/services/UpdateService.ts
@@ -1,19 +1,13 @@
 import { app, BrowserWindow } from 'electron';
 import log from 'electron-log';
 import { autoUpdater, type ProgressInfo, type UpdateInfo } from 'electron-updater';
+import type { CheckUpdateResult } from '../../shared/ipc';
+import { getErrorMessage } from '../utils/errors';
 
 type ReleaseNoteEntry = {
   note: string | null;
   version: string;
 };
-
-export interface CheckUpdateResult {
-  hasUpdate: boolean;
-  currentVersion: string;
-  latestVersion: string;
-  releaseNote?: string;
-  error?: string;
-}
 
 export class UpdateService {
   private mainWindow: BrowserWindow | null = null;
@@ -79,13 +73,13 @@ export class UpdateService {
         currentVersion,
         latestVersion: currentVersion,
       };
-    } catch (error: any) {
+    } catch (error) {
       log.error('Check update failed', error);
       return {
         hasUpdate: false,
         currentVersion,
         latestVersion: currentVersion,
-        error: error?.message || '检查更新失败',
+        error: getErrorMessage(error, '检查更新失败'),
       };
     }
   }
@@ -101,11 +95,11 @@ export class UpdateService {
     try {
       await autoUpdater.downloadUpdate();
       return { success: true };
-    } catch (error: any) {
+    } catch (error) {
       log.error('Download update failed', error);
       return {
         success: false,
-        error: error?.message || '下载更新失败',
+        error: getErrorMessage(error, '下载更新失败'),
       };
     }
   }

--- a/electron/sources/LocalSource.ts
+++ b/electron/sources/LocalSource.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { Readable } from 'stream';
-import { IMediaSource, FileItem } from '../interfaces/IMediaSource';
+import { IMediaSource, FileItem, type BatchRenameItem, type LocalSourceConnectConfig } from '../interfaces/IMediaSource';
 
 export class LocalSource implements IMediaSource {
   id: string;
@@ -14,7 +14,7 @@ export class LocalSource implements IMediaSource {
     this.name = name;
   }
 
-  async connect(config: { path: string }): Promise<boolean> {
+  async connect(config: LocalSourceConnectConfig): Promise<boolean> {
     try {
       if (!await fs.pathExists(config.path)) {
         return false;
@@ -74,7 +74,12 @@ export class LocalSource implements IMediaSource {
     }
   }
 
-  async batchRename(srcDir: string, renameObjects: Array<{ src_name: string, new_name: string }>, _batchSize?: number, onProgress?: (current: number, total: number) => void): Promise<boolean> {
+  async batchRename(
+    srcDir: string,
+    renameObjects: BatchRenameItem[],
+    _batchSize?: number,
+    onProgress?: (current: number, total: number) => void,
+  ): Promise<boolean> {
     try {
       const resolvedDir = this.resolveWithinRoot(srcDir);
       let processed = 0;

--- a/electron/sources/OpenListSource.ts
+++ b/electron/sources/OpenListSource.ts
@@ -1,14 +1,16 @@
 import { Readable } from 'stream';
-import { IMediaSource, FileItem } from '../interfaces/IMediaSource';
+import { IMediaSource, FileItem, type BatchRenameItem, type OpenListSourceConnectConfig } from '../interfaces/IMediaSource';
 import { FetchClient } from '../utils/FetchClient';
 import path from 'path';
 import { ProxyHelper } from '../utils/ProxyHelper';
+import type { OpenListListResponseData, OpenListResponse } from '../../shared/types';
+import { getNestedErrorMessage } from '../utils/errors';
 
 // Placeholder for OpenList (assuming HTTP based)
 export class OpenListSource implements IMediaSource {
   id: string;
   name: string;
-  type: 'openlist' = 'openlist';
+  type = 'openlist' as const;
   private baseUrl: string = '';
   private token: string = '';
   private api: FetchClient;
@@ -19,7 +21,7 @@ export class OpenListSource implements IMediaSource {
     this.api = FetchClient.create();
   }
 
-  async connect(config: { url: string, token?: string, proxyUrl?: string }): Promise<boolean> {
+  async connect(config: OpenListSourceConnectConfig): Promise<boolean> {
     this.baseUrl = config.url.replace(/\/$/, '');
     this.token = config.token || '';
 
@@ -35,12 +37,12 @@ export class OpenListSource implements IMediaSource {
     }
 
     try {
-      const response = await this.api.get(`${this.baseUrl}/api/me`, {
+      const response = await this.api.get<OpenListResponse>(`${this.baseUrl}/api/me`, {
         headers: { 'Authorization': this.token },
         timeout: 5000
       });
       return response.status === 200 && response.data?.code === 200;
-    } catch (e) {
+    } catch {
       return false;
     }
   }
@@ -57,7 +59,7 @@ export class OpenListSource implements IMediaSource {
     const reqPath = dirPath.startsWith('/') ? dirPath : '/' + dirPath;
 
     try {
-      const response = await this.api.post(`${this.baseUrl}/api/fs/list`, {
+      const response = await this.api.post<OpenListResponse<OpenListListResponseData>>(`${this.baseUrl}/api/fs/list`, {
         path: reqPath,
         password: "",
         page: 1,
@@ -71,41 +73,42 @@ export class OpenListSource implements IMediaSource {
         throw new Error(response.data.message || 'Failed to list directory');
       }
 
-      return response.data.data.content.map((item: any) => ({
+      return (response.data.data?.content ?? []).map((item) => ({
         name: item.name,
         path: path.posix.join(reqPath, item.name),
         isDir: item.is_dir,
         size: item.size
       }));
-    } catch (error: any) {
+    } catch (error) {
       console.error('OpenList listDir error:', error);
       throw error;
     }
   }
 
-  async getFileStream(_path: string): Promise<Readable> {
+  async getFileStream(filePath: string): Promise<Readable> {
+    void filePath;
     throw new Error('Method not implemented.');
   }
 
   async rename(oldPath: string, newPath: string): Promise<boolean> {
     if (!this.baseUrl) return false;
     try {
-      const response = await this.api.post(`${this.baseUrl}/api/fs/rename`, {
+      const response = await this.api.post<OpenListResponse>(`${this.baseUrl}/api/fs/rename`, {
         path: oldPath,
         name: path.posix.basename(newPath)
       }, {
         headers: { 'Authorization': this.token }
       });
       return response.data.code === 200;
-    } catch (e) {
-      console.error('OpenList rename error:', e);
+    } catch (error) {
+      console.error('OpenList rename error:', error);
       return false;
     }
   }
 
   async batchRename(
     srcDir: string,
-    renameObjects: Array<{ src_name: string, new_name: string }>,
+    renameObjects: BatchRenameItem[],
     batchSize: number = 20,
     onProgress?: (current: number, total: number) => void
   ): Promise<boolean> {
@@ -153,10 +156,10 @@ export class OpenListSource implements IMediaSource {
 
   private async executeSingleBatchRename(
     srcDir: string,
-    renameObjects: Array<{ src_name: string, new_name: string }>
+    renameObjects: BatchRenameItem[]
   ): Promise<boolean> {
     try {
-      const response = await this.api.post(`${this.baseUrl}/api/fs/batch_rename`, {
+      const response = await this.api.post<OpenListResponse>(`${this.baseUrl}/api/fs/batch_rename`, {
         src_dir: srcDir,
         rename_objects: renameObjects
       }, {
@@ -168,8 +171,13 @@ export class OpenListSource implements IMediaSource {
         return false;
       }
       return true;
-    } catch (e: any) {
-      console.error('OpenList batchRename error:', e.response?.data || e.message);
+    } catch (error) {
+      console.error(
+        'OpenList batchRename error:',
+        getNestedErrorMessage(error, (value) =>
+          typeof value.response?.data === 'string' ? value.response.data : undefined,
+        ),
+      );
       return false;
     }
   }
@@ -184,7 +192,7 @@ export class OpenListSource implements IMediaSource {
 
       // AList /api/fs/put can accept path as a query parameter or a header.
       // Moving it to query parameters is the most robust way to handle Unicode/Chinese characters.
-      const response = await this.api.put(`${this.baseUrl}/api/fs/put`, data, {
+      const response = await this.api.put<OpenListResponse>(`${this.baseUrl}/api/fs/put`, data, {
         params: {
           path: filePath
         },
@@ -201,9 +209,13 @@ export class OpenListSource implements IMediaSource {
         console.error('OpenList writeFile failed:', response.data.code, response.data.message);
       }
       return success;
-    } catch (e: any) {
-      const errorData = e.response?.data;
-      console.error('OpenList writeFile error:', errorData || e.message);
+    } catch (error) {
+      console.error(
+        'OpenList writeFile error:',
+        getNestedErrorMessage(error, (value) =>
+          typeof value.response?.data === 'string' ? value.response.data : undefined,
+        ),
+      );
       return false;
     }
   }

--- a/electron/utils/FetchClient.ts
+++ b/electron/utils/FetchClient.ts
@@ -1,216 +1,270 @@
-import fetch, { RequestInit, Request } from 'node-fetch';
+import fetch, {
+  type Headers,
+  type Request,
+  type RequestInit,
+} from 'node-fetch';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
-export interface FetchClientConfig extends RequestInit {
-    baseURL?: string;
-    params?: Record<string, string | number | boolean | undefined>;
-    timeout?: number;
-    proxyUrl?: string; // Add convenience proxy support
+type QueryParamValue = string | number | boolean | undefined;
+type RequestHeaders = Record<string, string>;
+
+export interface FetchClientConfig extends Omit<RequestInit, 'headers'> {
+  baseURL?: string;
+  params?: Record<string, QueryParamValue>;
+  timeout?: number;
+  proxyUrl?: string;
+  headers?: RequestHeaders;
 }
 
-export interface FetchResponse<T = any> {
-    data: T;
-    status: number;
-    statusText: string;
-    headers: any;
-    config: FetchClientConfig & { url: string };
-    request?: Request;
+export interface ResolvedFetchClientConfig extends FetchClientConfig {
+  url: string;
+}
+
+export interface FetchResponse<T = unknown> {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: Headers;
+  config: ResolvedFetchClientConfig;
+  request?: Request;
+}
+
+export interface FetchClientError<T = unknown> extends Error {
+  response?: FetchResponse<T>;
+  config?: ResolvedFetchClientConfig;
 }
 
 export type Interceptor<V> = {
-    onFulfilled?: (value: V) => V | Promise<V>;
-    onRejected?: (error: any) => any;
+  onFulfilled?: (value: V) => V | Promise<V>;
+  onRejected?: (error: unknown) => unknown;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isFetchResponse<T>(value: unknown): value is FetchResponse<T> {
+  return isRecord(value) && typeof value.status === 'number' && 'config' in value;
+}
+
 export class FetchClient {
-    public defaults: FetchClientConfig;
-    public interceptors = {
-        request: {
-            handlers: [] as Interceptor<FetchClientConfig>[],
-            use(onFulfilled?: (value: FetchClientConfig) => FetchClientConfig | Promise<FetchClientConfig>, onRejected?: (error: any) => any) {
-                this.handlers.push({ onFulfilled, onRejected });
-                return this.handlers.length - 1;
-            }
-        },
-        response: {
-            handlers: [] as Interceptor<FetchResponse>[],
-            use(onFulfilled?: (value: FetchResponse) => FetchResponse | Promise<FetchResponse>, onRejected?: (error: any) => any) {
-                this.handlers.push({ onFulfilled, onRejected });
-                return this.handlers.length - 1;
-            }
+  public defaults: FetchClientConfig;
+
+  public interceptors = {
+    request: {
+      handlers: [] as Interceptor<ResolvedFetchClientConfig>[],
+      use: (
+        onFulfilled?: (
+          value: ResolvedFetchClientConfig,
+        ) => ResolvedFetchClientConfig | Promise<ResolvedFetchClientConfig>,
+        onRejected?: (error: unknown) => unknown,
+      ) => {
+        this.interceptors.request.handlers.push({ onFulfilled, onRejected });
+        return this.interceptors.request.handlers.length - 1;
+      },
+    },
+    response: {
+      handlers: [] as Interceptor<FetchResponse>[],
+      use: (
+        onFulfilled?: (
+          value: FetchResponse,
+        ) => FetchResponse | Promise<FetchResponse>,
+        onRejected?: (error: unknown) => unknown,
+      ) => {
+        this.interceptors.response.handlers.push({ onFulfilled, onRejected });
+        return this.interceptors.response.handlers.length - 1;
+      },
+    },
+  };
+
+  constructor(defaults: FetchClientConfig = {}) {
+    this.defaults = defaults;
+  }
+
+  static create(defaults: FetchClientConfig = {}) {
+    return new FetchClient(defaults);
+  }
+
+  private async request<T = unknown>(
+    url: string,
+    config: FetchClientConfig = {},
+  ): Promise<FetchResponse<T>> {
+    let fullUrl = url;
+    if (config.baseURL && !url.startsWith('http')) {
+      const base = config.baseURL.replace(/\/$/, '');
+      const relativePath = url.replace(/^\//, '');
+      fullUrl = `${base}/${relativePath}`;
+    } else if (this.defaults.baseURL && !url.startsWith('http')) {
+      const base = this.defaults.baseURL.replace(/\/$/, '');
+      const relativePath = url.replace(/^\//, '');
+      fullUrl = `${base}/${relativePath}`;
+    }
+
+    const params = { ...this.defaults.params, ...config.params };
+    if (params && Object.keys(params).length > 0) {
+      const parsedUrl = new URL(fullUrl);
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined) {
+          parsedUrl.searchParams.append(key, String(value));
         }
+      });
+      fullUrl = parsedUrl.toString();
+    }
+
+    let mergedConfig: ResolvedFetchClientConfig = {
+      ...this.defaults,
+      ...config,
+      params,
+      headers: {
+        ...this.defaults.headers,
+        ...config.headers,
+      },
+      url: fullUrl,
     };
 
-    constructor(defaults: FetchClientConfig = {}) {
-        this.defaults = defaults;
+    for (const handler of this.interceptors.request.handlers) {
+      if (handler.onFulfilled) {
+        mergedConfig = await handler.onFulfilled(mergedConfig);
+      }
     }
 
-    static create(defaults: FetchClientConfig = {}) {
-        return new FetchClient(defaults);
+    const {
+      timeout,
+      proxyUrl,
+      baseURL,
+      params: _params,
+      url: resolvedUrl,
+      ...fetchOptions
+    } = mergedConfig;
+    void baseURL;
+    void _params;
+    void resolvedUrl;
+
+    let timer: NodeJS.Timeout | null = null;
+    if (timeout) {
+      const controller = new AbortController();
+      fetchOptions.signal = controller.signal;
+      timer = setTimeout(() => controller.abort(), timeout);
     }
 
-    private async request<T = any>(url: string, config: FetchClientConfig = {}): Promise<FetchResponse<T>> {
-        // 1. Merge Config
-        let mergedConfig: FetchClientConfig = { ...this.defaults, ...config };
-        mergedConfig.params = { ...this.defaults.params, ...config.params };
-        mergedConfig.headers = { ...this.defaults.headers, ...config.headers };
+    if (proxyUrl) {
+      try {
+        fetchOptions.agent = new HttpsProxyAgent(proxyUrl);
+      } catch {
+        console.warn('Invalid proxy URL in FetchClient:', proxyUrl);
+      }
+    } else if (this.defaults.proxyUrl && !config.agent) {
+      try {
+        fetchOptions.agent = new HttpsProxyAgent(this.defaults.proxyUrl);
+      } catch {
+        console.warn('Invalid default proxy URL in FetchClient:', this.defaults.proxyUrl);
+      }
+    }
 
-        // Set full URL
-        let fullUrl = url;
-        if (mergedConfig.baseURL && !url.startsWith('http')) {
-            // Handle trailing slash in baseURL and leading slash in url
-            const base = mergedConfig.baseURL.replace(/\/$/, '');
-            const path = url.replace(/^\//, '');
-            fullUrl = `${base}/${path}`;
+    try {
+      const response = await fetch(fullUrl, fetchOptions);
+      if (timer) {
+        clearTimeout(timer);
+      }
+
+      const contentType = response.headers.get('content-type');
+      const responseData: unknown =
+        contentType && contentType.includes('application/json')
+          ? await response.json()
+          : await response.text();
+
+      let fetchResponse: FetchResponse<T> = {
+        data: responseData as T,
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+        config: mergedConfig,
+        request: undefined,
+      };
+
+      for (const handler of this.interceptors.response.handlers) {
+        if (handler.onFulfilled) {
+          fetchResponse = await handler.onFulfilled(fetchResponse) as FetchResponse<T>;
+        }
+      }
+
+      if (fetchResponse.status < 200 || fetchResponse.status >= 300) {
+        const error = new Error(
+          `Request failed with status code ${fetchResponse.status}`,
+        ) as FetchClientError<T>;
+        error.response = fetchResponse;
+        error.config = mergedConfig;
+        throw error;
+      }
+
+      return fetchResponse;
+    } catch (error) {
+      if (timer) {
+        clearTimeout(timer);
+      }
+
+      let currentError: unknown = error;
+      for (const handler of this.interceptors.response.handlers) {
+        if (!handler.onRejected) {
+          continue;
         }
 
-        // Append Params
-        if (mergedConfig.params) {
-            const u = new URL(fullUrl);
-            Object.entries(mergedConfig.params).forEach(([key, value]) => {
-                if (value !== undefined) u.searchParams.append(key, String(value));
-            });
-            fullUrl = u.toString();
-        }
-
-        // Explicitly add url to config for interceptors and response
-        (mergedConfig as any).url = fullUrl;
-
-        // 2. Request Interceptors
         try {
-            for (const handler of this.interceptors.request.handlers) {
-                if (handler.onFulfilled) mergedConfig = await handler.onFulfilled(mergedConfig);
-            }
-        } catch (e) {
-            // If request interceptor fails
-            return Promise.reject(e);
+          const result = await handler.onRejected(currentError);
+          if (isFetchResponse<T>(result)) {
+            return result;
+          }
+          currentError = result;
+        } catch (innerError) {
+          currentError = innerError;
         }
+      }
 
-        // 3. Prepare Fetch Options
-        const { timeout, proxyUrl, ...fetchOptions } = mergedConfig;
-
-        // Timeout
-        let timer: NodeJS.Timeout | null = null;
-        if (timeout) {
-            const controller = new AbortController();
-            fetchOptions.signal = controller.signal as any; // Type cast for node-fetch compatibility
-            timer = setTimeout(() => controller.abort(), timeout);
-        }
-
-        // Proxy
-        if (proxyUrl) {
-            // Only create agent if not already present? 
-            // Axios prioritizes request config > defaults. We merged them.
-            try {
-                (fetchOptions as any).agent = new HttpsProxyAgent(proxyUrl);
-            } catch (e) {
-                console.warn('Invalid proxy URL in FetchClient:', proxyUrl);
-            }
-        } else if (this.defaults.proxyUrl && !config.agent) {
-            // Fallback to default proxy if not overridden
-            try {
-                (fetchOptions as any).agent = new HttpsProxyAgent(this.defaults.proxyUrl);
-            } catch (e) {
-                console.warn('Invalid default proxy URL in FetchClient:', this.defaults.proxyUrl);
-            }
-        }
-
-        try {
-            const response = await fetch(fullUrl, fetchOptions);
-            if (timer) clearTimeout(timer);
-
-            // 4. Transform Response
-            let data: any;
-            const contentType = response.headers.get('content-type');
-            if (contentType && contentType.includes('application/json')) {
-                data = await response.json();
-            } else {
-                data = await response.text();
-            }
-
-            let fetchResponse: FetchResponse<T> = {
-                data: data as T,
-                status: response.status,
-                statusText: response.statusText,
-                headers: response.headers,
-                config: mergedConfig as FetchClientConfig & { url: string },
-                request: undefined // node-fetch doesn't expose underlying request object easily in same way, leaving undefined
-            };
-
-            // 5. Response Interceptors (Success)
-            for (const handler of this.interceptors.response.handlers) {
-                if (handler.onFulfilled) fetchResponse = await handler.onFulfilled(fetchResponse);
-            }
-
-            // Check for HTTP errors (Axios throws on non-2xx by default)
-            // Note: Interceptors might handle this (e.g. logging), but we should probably throw 
-            // if the final status is an error, to mimic axios.
-            // Axios logic: validateStatus (default: 2xx).
-            if (fetchResponse.status < 200 || fetchResponse.status >= 300) {
-                const error: any = new Error(`Request failed with status code ${fetchResponse.status}`);
-                error.response = fetchResponse;
-                error.config = mergedConfig;
-                throw error;
-            }
-
-            return fetchResponse;
-
-        } catch (error: any) {
-            if (timer) clearTimeout(timer);
-
-            // 5. Response Interceptors (Error)
-            let rejectedPromise: Promise<any> = Promise.reject(error);
-            for (const handler of this.interceptors.response.handlers) {
-                if (handler.onRejected) {
-                    try {
-                        // If handler returns specific value/promise, we resolve? 
-                        // Axios docs: "If you want to skip the error handling, simply do not pass the error handler"
-                        // Actually usually onRejected returns a new Promise or throws.
-                        const result = await handler.onRejected(error);
-                        // If it returns, we assume it recovered? This is complex. 
-                        // For simplicity: if it returns, we resolve with that.
-                        rejectedPromise = Promise.resolve(result as any);
-                    } catch (innerError) {
-                        rejectedPromise = Promise.reject(innerError);
-                    }
-                }
-            }
-            return rejectedPromise;
-        }
+      throw currentError;
     }
+  }
 
-    get<T = any>(url: string, config: FetchClientConfig = {}) {
-        return this.request<T>(url, { ...config, method: 'GET' });
-    }
+  get<T = unknown>(url: string, config: FetchClientConfig = {}) {
+    return this.request<T>(url, { ...config, method: 'GET' });
+  }
 
-    post<T = any>(url: string, data?: any, config: FetchClientConfig = {}) {
-        return this.request<T>(url, {
-            ...config,
-            method: 'POST',
-            body: data ? JSON.stringify(data) : undefined,
-            headers: { ...config.headers, 'Content-Type': 'application/json' }
-        });
-    }
+  post<T = unknown>(url: string, data?: unknown, config: FetchClientConfig = {}) {
+    return this.request<T>(url, {
+      ...config,
+      method: 'POST',
+      body: data ? JSON.stringify(data) : undefined,
+      headers: { ...config.headers, 'Content-Type': 'application/json' },
+    });
+  }
 
-    put<T = any>(url: string, data?: any, config: FetchClientConfig = {}) {
-        return this.request<T>(url, {
-            ...config,
-            method: 'PUT',
-            body: typeof data === 'object' && !Buffer.isBuffer(data) ? JSON.stringify(data) : data,
-            // Helper: if object map to json, if string/buffer leave as is
-            headers: {
-                ...config.headers,
-                ...(typeof data === 'object' && !Buffer.isBuffer(data) ? { 'Content-Type': 'application/json' } : {})
-            }
-        });
-    }
+  put<T = unknown>(
+    url: string,
+    data?: RequestInit['body'] | Record<string, unknown>,
+    config: FetchClientConfig = {},
+  ) {
+    const isJsonBody =
+      typeof data === 'object' &&
+      data !== null &&
+      !Buffer.isBuffer(data) &&
+      !(data instanceof ArrayBuffer) &&
+      !(ArrayBuffer.isView(data));
 
-    delete<T = any>(url: string, config: FetchClientConfig = {}) {
-        return this.request<T>(url, { ...config, method: 'DELETE' });
-    }
+    return this.request<T>(url, {
+      ...config,
+      method: 'PUT',
+      body: isJsonBody ? JSON.stringify(data) : (data as RequestInit['body']),
+      headers: {
+        ...config.headers,
+        ...(isJsonBody ? { 'Content-Type': 'application/json' } : {}),
+      },
+    });
+  }
 
-    // Helper for simple "is this error from us" checks
-    static isFetchError(error: any): boolean {
-        return !!error.response && !!error.config;
-    }
+  delete<T = unknown>(url: string, config: FetchClientConfig = {}) {
+    return this.request<T>(url, { ...config, method: 'DELETE' });
+  }
+
+  static isFetchError(error: unknown): error is FetchClientError {
+    return isRecord(error) && ('response' in error || 'config' in error);
+  }
 }

--- a/electron/utils/errors.ts
+++ b/electron/utils/errors.ts
@@ -1,0 +1,41 @@
+import type { ErrorResponse } from '../../shared/ipc';
+
+type ErrorLike = {
+  message?: string;
+  response?: {
+    data?: unknown;
+    status?: number;
+  };
+};
+
+export function getErrorMessage(error: unknown, fallback = '发生未知错误'): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error) {
+    return error;
+  }
+
+  return fallback;
+}
+
+export function getNestedErrorMessage(
+  error: unknown,
+  extractor: (value: ErrorLike) => string | undefined,
+  fallback = '发生未知错误',
+): string {
+  if (typeof error !== 'object' || error === null) {
+    return getErrorMessage(error, fallback);
+  }
+
+  const extracted = extractor(error as ErrorLike);
+  return extracted || getErrorMessage(error, fallback);
+}
+
+export function toErrorResponse(error: unknown, fallback = '发生未知错误'): ErrorResponse {
+  return {
+    success: false,
+    error: getErrorMessage(error, fallback),
+  };
+}

--- a/shared/ipc.ts
+++ b/shared/ipc.ts
@@ -1,0 +1,203 @@
+import type {
+  BatchOptions,
+  EpisodeConfirmationPayload,
+  EpisodeData,
+  EpisodeMatchItem,
+  FileItem,
+  MetadataProgressPayload,
+  RuleDefinition,
+  ScannerLogPayload,
+  ScannerOperationProgressPayload,
+  SearchResult,
+  SourceType,
+  ThemeMode,
+  UpdateDownloadProgressPayload,
+  UpdateDownloadedPayload,
+  ViewMode,
+  LogLevel,
+} from './types';
+import type { ScrapedMediaRecord } from '../src/stores/appStore';
+
+export interface SuccessResponse {
+  success: true;
+}
+
+export interface ErrorResponse {
+  success: false;
+  error: string;
+}
+
+export type AsyncResult<T> = ({ success: true } & T) | ErrorResponse;
+
+export interface ExplorerConfig {
+  localPath?: string;
+  openListUrl?: string;
+  openListToken?: string;
+}
+
+export interface ExplorerListRequest {
+  type: SourceType;
+  path: string;
+  config: ExplorerConfig;
+}
+
+export type ExplorerListResponse = AsyncResult<{
+  data: FileItem[];
+  currentPath: string;
+}>;
+
+export interface SourceBaseRequest {
+  type: SourceType;
+  id: string;
+  path: string;
+  url?: string;
+  token?: string;
+}
+
+export interface ScanSourceRequest extends SourceBaseRequest {
+  rootPath?: string;
+}
+
+export interface ScanSelectedRequest extends SourceBaseRequest {
+  paths: string[];
+}
+
+export interface LlmTestRequest {
+  apiKey: string;
+  baseURL?: string;
+}
+
+export type LlmTestResponse = AsyncResult<{
+  models: string[];
+}>;
+
+export interface OpenListTestRequest {
+  url: string;
+  token: string;
+}
+
+export interface MetadataDetailRequest {
+  showId: string;
+  season: number;
+  episode: number;
+}
+
+export interface FetchMetadataRequest {
+  matches: EpisodeMatchItem[];
+  seriesId: string;
+}
+
+export type FetchMetadataResponse = AsyncResult<{
+  matches: EpisodeMatchItem[];
+}>;
+
+export interface SmartIdentifyRequest {
+  unmatchedFiles: EpisodeMatchItem[];
+}
+
+export type SmartIdentifyResponse = AsyncResult<{
+  results: EpisodeMatchItem[];
+}>;
+
+export interface CheckUpdateResult {
+  hasUpdate: boolean;
+  currentVersion: string;
+  latestVersion: string;
+  releaseNote?: string;
+  error?: string;
+}
+
+export interface DownloadUpdateResult {
+  success: boolean;
+  error?: string;
+}
+
+export type ConfigValueMap = {
+  tmdb_api_key: string;
+  openai_api_key: string;
+  openai_base_url: string;
+  openai_model: string;
+  proxy_url: string;
+  source_type: SourceType;
+  local_path: string;
+  openlist_url: string;
+  openlist_token: string;
+  openlist_batch_size: string;
+  video_extensions: string;
+  view_mode: ViewMode;
+  batch_options: BatchOptions;
+  theme: ThemeMode;
+  log_level: LogLevel;
+};
+
+export type ConfigKey = keyof ConfigValueMap;
+
+export interface ScannerRequireConfirmationPayload {
+  detectedName: string;
+  results: SearchResult[];
+}
+
+export interface ScannerConfirmResponsePayload {
+  seriesId: string | null;
+  newName?: string;
+  seriesName?: string;
+}
+
+export interface ScannerEpisodesConfirmResponsePayload {
+  confirmed: boolean;
+  options?: BatchOptions;
+  selectedIndices: number[];
+  updatedMatches?: EpisodeMatchItem[];
+}
+
+export interface RendererEventPayloadMap {
+  'main-process-message': string;
+  'metadata-progress': MetadataProgressPayload;
+  'scanner-log': ScannerLogPayload;
+  'scanner-finished': undefined;
+  'scanner-require-confirmation': ScannerRequireConfirmationPayload;
+  'scanner-require-episodes-confirmation': EpisodeConfirmationPayload;
+  'scanner-operation-progress': ScannerOperationProgressPayload;
+  'update:download-progress': UpdateDownloadProgressPayload;
+  'update:downloaded': UpdateDownloadedPayload;
+  'update:error': { message: string };
+}
+
+export type RendererEventChannel = keyof RendererEventPayloadMap;
+
+export interface WindowIpcRenderer {
+  invoke(channel: 'app:getVersion'): Promise<string>;
+  invoke<K extends ConfigKey>(channel: 'config:get', key: K): Promise<ConfigValueMap[K] | undefined>;
+  invoke<K extends ConfigKey>(channel: 'config:set', key: K, value: ConfigValueMap[K]): Promise<void>;
+  invoke(channel: 'dialog:openDirectory'): Promise<string | null>;
+  invoke(channel: 'explorer:list', request: ExplorerListRequest): Promise<ExplorerListResponse>;
+  invoke(channel: 'llm:test', request: LlmTestRequest): Promise<LlmTestResponse>;
+  invoke(channel: 'media:getAll'): Promise<ScrapedMediaRecord[]>;
+  invoke(channel: 'metadata:getEpisodeDetail', request: MetadataDetailRequest): Promise<EpisodeData | null>;
+  invoke(channel: 'openlist:test', request: OpenListTestRequest): Promise<AsyncResult<Record<string, never>>>;
+  invoke(channel: 'proxy:test'): Promise<AsyncResult<Record<string, never>>>;
+  invoke(channel: 'rules:get'): Promise<RuleDefinition[]>;
+  invoke(channel: 'rules:save', rules: RuleDefinition[]): Promise<SuccessResponse>;
+  invoke(channel: 'scanner:fetch-metadata', request: FetchMetadataRequest): Promise<FetchMetadataResponse>;
+  invoke(channel: 'scanner:identify-single', request: ScanSourceRequest): Promise<AsyncResult<Record<string, never>>>;
+  invoke(channel: 'scanner:scan-selected', request: ScanSelectedRequest): Promise<AsyncResult<Record<string, never>>>;
+  invoke(channel: 'scanner:smart-identify', request: SmartIdentifyRequest): Promise<SmartIdentifyResponse>;
+  invoke(channel: 'scanner:start', request: ScanSourceRequest): Promise<AsyncResult<Record<string, never>>>;
+  invoke(channel: 'tmdb:test', token: string): Promise<AsyncResult<Record<string, never>>>;
+  invoke(channel: 'update:check'): Promise<CheckUpdateResult>;
+  invoke(channel: 'update:download'): Promise<DownloadUpdateResult>;
+  invoke(channel: 'update:install'): Promise<boolean>;
+
+  on<K extends RendererEventChannel>(
+    channel: K,
+    listener: RendererEventPayloadMap[K] extends undefined
+      ? () => void
+      : (payload: RendererEventPayloadMap[K]) => void,
+  ): () => void;
+
+  send(channel: 'scanner-confirm-response', payload: ScannerConfirmResponsePayload): void;
+  send(channel: 'scanner-episodes-confirm-response', payload: ScannerEpisodesConfirmResponsePayload): void;
+  send(channel: 'window:close'): void;
+  send(channel: 'window:maximize'): void;
+  send(channel: 'window:minimize'): void;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,0 +1,170 @@
+export type SourceType = 'local' | 'openlist';
+
+export type LogType = 'info' | 'success' | 'error' | 'warn' | 'debug';
+export type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+export type ThemeMode = 'dark' | 'light';
+export type ViewMode = 'grid' | 'list';
+export type RuleType = 'tv' | 'movie' | 'anime';
+
+export interface RuleDefinition {
+  id: string;
+  pattern: string;
+  type: RuleType;
+}
+
+export interface FileItem {
+  name: string;
+  path: string;
+  isDir: boolean;
+  size?: number;
+  mtime?: Date;
+}
+
+export interface SearchResult {
+  id: string;
+  title: string;
+  originalTitle?: string;
+  year?: string;
+  poster?: string;
+  overview?: string;
+  provider: string;
+}
+
+export interface EpisodeData {
+  id: string;
+  seasonNumber: number;
+  episodeNumber: number;
+  title: string;
+  overview?: string;
+  airDate?: string;
+  stillPath?: string;
+  runtime?: number;
+}
+
+export type MatchSource =
+  | 'regex'
+  | 'llm'
+  | 'manual'
+  | 'llm_context'
+  | 'llm_dir'
+  | 'unmatched'
+  | 'llm_failed'
+  | 'llm_error';
+
+export interface MatchResult {
+  success: boolean;
+  seriesName?: string | null;
+  season?: number | null;
+  episode?: number | null;
+  year?: string;
+  confidence?: number;
+  source: MatchSource;
+}
+
+export interface ResolvedEpisodeMatch extends MatchResult {
+  originalEpisode?: number | null;
+  totalEpisodes?: number;
+}
+
+export interface EpisodeMatchItem {
+  file: FileItem;
+  match: ResolvedEpisodeMatch;
+  metadata?: EpisodeData;
+  tmdbId?: string;
+}
+
+export interface BatchOptions {
+  rename: boolean;
+  writeNfo: boolean;
+  writePoster: boolean;
+  writeStill: boolean;
+}
+
+export interface EpisodeConfirmationPayload {
+  seriesName: string;
+  matches: EpisodeMatchItem[];
+}
+
+export interface MetadataProgressPayload {
+  current: number;
+  total: number;
+}
+
+export interface ScannerOperationProgressPayload {
+  percent: number;
+  message: string;
+  finished: boolean;
+}
+
+export interface ScannerLogPayload {
+  message: string;
+  type: LogType;
+}
+
+export interface UpdateDownloadProgressPayload {
+  bytesPerSecond: number;
+  delta: number;
+  percent: number;
+  total: number;
+  transferred: number;
+}
+
+export interface UpdateDownloadedPayload {
+  version: string;
+  releaseNote: string;
+}
+
+export interface EpisodeDetailState extends EpisodeData {
+  season?: number | null;
+  episode?: number | null;
+}
+
+export interface OpenListListItem {
+  name: string;
+  is_dir: boolean;
+  size?: number;
+}
+
+export interface OpenListListResponseData {
+  content?: OpenListListItem[];
+}
+
+export interface OpenListResponse<TData = unknown> {
+  code: number;
+  message?: string;
+  data?: TData;
+  success?: boolean;
+}
+
+export interface TmdbSearchResultItem {
+  id: number;
+  name: string;
+  original_name?: string;
+  first_air_date?: string;
+  poster_path?: string | null;
+  overview?: string;
+}
+
+export interface TmdbSearchResponse {
+  results: TmdbSearchResultItem[];
+}
+
+export interface TmdbEpisodeItem {
+  id: number;
+  season_number: number;
+  episode_number: number;
+  name: string;
+  overview?: string;
+  air_date?: string;
+  still_path?: string | null;
+  runtime?: number;
+}
+
+export interface TmdbSeasonResponse {
+  episodes: TmdbEpisodeItem[];
+}
+
+export interface TmdbAuthResponse {
+  success?: boolean;
+  status_message?: string;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,29 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useState, type CSSProperties, type ReactNode } from 'react';
 import { useAppStore, LogType, ScrapedMediaRecord } from './stores/appStore';
 import { Settings, Database, Globe, Play, Eye, EyeOff, CheckCircle2, AlertCircle, RefreshCw, Save, ArrowRight, Minus, Square, X, Folder, Network, Zap, File, Clapperboard, ChevronUp, ChevronDown, LayoutGrid, List, Wand2, Sun, Moon, ArrowLeft, CornerLeftUp, Check, Calendar, Clock, Trash2, Download, Sparkles } from 'lucide-react';
 import clsx from 'clsx';
+import type {
+  ScannerRequireConfirmationPayload,
+} from '../shared/ipc';
+import type {
+  BatchOptions,
+  EpisodeConfirmationPayload,
+  EpisodeDetailState,
+  EpisodeMatchItem,
+  FileItem,
+  LogLevel,
+  MetadataProgressPayload,
+  RuleDefinition,
+  ScannerLogPayload,
+  ScannerOperationProgressPayload,
+  SearchResult,
+  ThemeMode,
+  UpdateDownloadedPayload,
+  UpdateDownloadProgressPayload,
+  ViewMode,
+} from '../shared/types';
+
+type StatusResult = { success: boolean; message: string };
 
 type UpdateInfoState = {
   currentVersion: string;
@@ -9,7 +31,25 @@ type UpdateInfoState = {
   releaseNote: string;
 };
 
-const StatusMessage = ({ result }: { result: { success: boolean; message: string } | null }) => {
+type WizardState = {
+  detectedName?: string;
+  seriesResults?: SearchResult[];
+  seriesName?: string;
+  seriesId?: string;
+  matches?: EpisodeMatchItem[];
+};
+
+const dragRegionStyle: CSSProperties & { WebkitAppRegion: 'drag' } = { WebkitAppRegion: 'drag' };
+const noDragRegionStyle: CSSProperties & { WebkitAppRegion: 'no-drag' } = { WebkitAppRegion: 'no-drag' };
+const defaultBatchOptions: BatchOptions = { rename: true, writeNfo: true, writePoster: true, writeStill: true };
+const batchOptionDefinitions: Array<{ id: keyof BatchOptions; label: string }> = [
+  { id: 'rename', label: '重命名' },
+  { id: 'writeNfo', label: '生成 NFO' },
+  { id: 'writePoster', label: '下载海报' },
+  { id: 'writeStill', label: '下载剧照' },
+];
+
+const StatusMessage = ({ result }: { result: StatusResult | null }) => {
   if (!result) return null;
   return (
     <div className={clsx("text-[11px] font-medium flex items-center gap-1.5 animate-in fade-in slide-in-from-left-1", result.success ? "text-green-500" : "text-red-500")}>
@@ -70,6 +110,12 @@ const formatRelativeScrapedAt = (value?: string) => {
 const basename = (input: string) => {
   const normalized = input.replace(/\\/g, '/');
   return normalized.split('/').filter(Boolean).pop() || input;
+};
+
+const getErrorMessage = (error: unknown, fallback = '未知错误') => {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error) return error;
+  return fallback;
 };
 
 const LogItem = ({ log }: { log: { message: string, type: LogType, timestamp: number } }) => {
@@ -247,7 +293,7 @@ export default function App() {
 
   // Explorer
   const [currentPath, setCurrentPath] = useState('');
-  const [fileList, setFileList] = useState<Array<{ name: string, path: string, isDir: boolean, size: number }>>([]);
+  const [fileList, setFileList] = useState<FileItem[]>([]);
   const [loadingFiles, setLoadingFiles] = useState(false);
   const [navHistory, setNavHistory] = useState<string[]>([]);
 
@@ -260,32 +306,26 @@ export default function App() {
   const [showOpenaiKey, setShowOpenaiKey] = useState(false);
   const [showOpenListToken, setShowOpenListToken] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved'>('idle');
-  const [rules, setRules] = useState<Array<{ id: string, pattern: string, type: string }>>([]);
+  const [rules, setRules] = useState<RuleDefinition[]>([]);
 
   const [isTestingLLM, setIsTestingLLM] = useState(false);
-  const [llmTestResult, setLlmTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [llmTestResult, setLlmTestResult] = useState<StatusResult | null>(null);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [isTestingTmdb, setIsTestingTmdb] = useState(false);
-  const [tmdbTestResult, setTmdbTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [tmdbTestResult, setTmdbTestResult] = useState<StatusResult | null>(null);
   const [isTestingProxy, setIsTestingProxy] = useState(false);
-  const [proxyTestResult, setProxyTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [proxyTestResult, setProxyTestResult] = useState<StatusResult | null>(null);
   const [isTestingOpenList, setIsTestingOpenList] = useState(false);
-  const [openListTestResult, setOpenListTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [openListTestResult, setOpenListTestResult] = useState<StatusResult | null>(null);
 
   // Wizard
   const [wizardStage, setWizardWizardStage] = useState<'idle' | 'series' | 'loading_episodes' | 'episodes' | 'executing' | 'finished'>('idle');
-  const [wizardData, setWizardData] = useState<{
-    detectedName?: string,
-    seriesResults?: any[],
-    seriesName?: string,
-    seriesId?: string,  // TMDB ID
-    matches?: any[]
-  }>({});
+  const [wizardData, setWizardData] = useState<WizardState>({});
   const [scrapeProgress, setScrapeProgress] = useState<{ percent: number, message: string }>({ percent: 0, message: '' });
   const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
-  const [batchOptions, setBatchOptions] = useState({ rename: true, writeNfo: true, writePoster: true, writeStill: true });
+  const [batchOptions, setBatchOptions] = useState<BatchOptions>(defaultBatchOptions);
 
-  const [selectedEpisodeDetail, setSelectedEpisodeDetail] = useState<any | null>(null);
+  const [selectedEpisodeDetail, setSelectedEpisodeDetail] = useState<EpisodeDetailState | null>(null);
   const [, setLoadingDetail] = useState(false);
   const [editingMatchIndex, setEditingMatchIndex] = useState<number | null>(null);
   const [editMatchValues, setEditMatchValues] = useState({ season: 1, episode: 1 });
@@ -314,12 +354,12 @@ export default function App() {
   const [videoExtsInput, setVideoExtsInput] = useState('');
 
   // General Settings
-  const [theme, setTheme] = useState<'dark' | 'light'>('dark');
-  const [logLevel, setLogLevel] = useState<'info' | 'warn' | 'error'>('info');
+  const [theme, setTheme] = useState<ThemeMode>('dark');
+  const [logLevel, setLogLevel] = useState<LogLevel>('info');
 
   // UI State
   const [activeUtilityPanel, setActiveUtilityPanel] = useState<'history' | 'logs' | null>(null);
-  const [viewMode, setViewMode] = useState<'grid' | 'list'>('list');
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
 
   // Update State
   const [appVersion, setAppVersion] = useState('');
@@ -330,6 +370,20 @@ export default function App() {
   const [downloadProgress, setDownloadProgress] = useState(0);
   const [isUpdateReady, setIsUpdateReady] = useState(false);
   const [isRefreshingHistory, setIsRefreshingHistory] = useState(false);
+
+  const refreshMedia = useCallback(async (options?: { silent?: boolean }) => {
+    setIsRefreshingHistory(true);
+    try {
+      const allMedia = await window.ipcRenderer.invoke('media:getAll');
+      setMedia(Array.isArray(allMedia) ? allMedia : []);
+    } catch (error) {
+      if (!options?.silent) {
+        addLog(`刷新历史记录失败: ${getErrorMessage(error)}`, 'error');
+      }
+    } finally {
+      setIsRefreshingHistory(false);
+    }
+  }, [addLog, setMedia]);
 
   // Initial Configuration Loading
   useEffect(() => {
@@ -382,13 +436,13 @@ export default function App() {
       }
     };
 
-    const handleLog = (data: any) => addLog(data.message, data.type);
+    const handleLog = (data: ScannerLogPayload) => addLog(data.message, data.type);
     const handleFinished = () => {
       setScanning(false);
       addLog('扫描任务全部完成。', 'success');
       refreshMedia();
     };
-    const handleConfirmation = (data: any) => {
+    const handleConfirmation = (data: ScannerRequireConfirmationPayload) => {
       setMetadataFetched(false);
       setFetchingMetadata(false);
       setMetadataProgress({ current: 0, total: 0 });
@@ -396,29 +450,29 @@ export default function App() {
       setManualSeriesName(data.detectedName); // Initialize with detected name
       setWizardWizardStage('series');
     };
-    const handleEpisodesConfirmation = (data: any) => {
+    const handleEpisodesConfirmation = (data: EpisodeConfirmationPayload) => {
       setMetadataFetched(false);
       setFetchingMetadata(false);
       setMetadataProgress({ current: 0, total: 0 });
       setWizardData(prev => ({
         ...prev,
         seriesName: data.seriesName,
-        seriesId: data.seriesId || (data.matches && data.matches[0]?.tmdbId),
+        seriesId: data.matches[0]?.tmdbId,
         matches: data.matches
       }));
-      setSelectedIndices(data.matches.map((_: any, i: number) => i));
+      setSelectedIndices(data.matches.map((_, i) => i));
       setWizardWizardStage('episodes');
     };
-    const handleProgress = (data: any) => {
+    const handleProgress = (data: ScannerOperationProgressPayload) => {
       setScrapeProgress({ percent: data.percent, message: data.message });
       if (data.finished) setWizardWizardStage('finished');
     };
 
-    const handleDownloadProgress = (data: any) => {
+    const handleDownloadProgress = (data: UpdateDownloadProgressPayload) => {
       setDownloadProgress(Number(data.percent));
     };
 
-    const handleUpdateDownloaded = (data: any) => {
+    const handleUpdateDownloaded = (data: UpdateDownloadedPayload) => {
       setIsDownloadingUpdate(false);
       setIsUpdateReady(true);
       setDownloadProgress(100);
@@ -451,21 +505,16 @@ export default function App() {
 
     loadConfig();
     return () => {
-      if (typeof cleanupLog === 'function') (cleanupLog as any)();
-      if (typeof cleanupFinished === 'function') (cleanupFinished as any)();
-      if (typeof cleanupConf === 'function') (cleanupConf as any)();
-      if (typeof cleanupEpConf === 'function') (cleanupEpConf as any)();
-      if (typeof cleanupProgress === 'function') (cleanupProgress as any)();
-      if (typeof cleanupDlProgress === 'function') (cleanupDlProgress as any)();
-      if (typeof cleanupDownloaded === 'function') (cleanupDownloaded as any)();
+      [cleanupLog, cleanupFinished, cleanupConf, cleanupEpConf, cleanupProgress, cleanupDlProgress, cleanupDownloaded]
+        .forEach((cleanup) => cleanup());
     };
-  }, []);
+  }, [addLog, refreshMedia, setConfig, setScanning, setVideoExtensions]);
 
   // 监听元数据获取进度
   useEffect(() => {
     if (!window.ipcRenderer) return;
 
-    const handleProgress = (_: any, progress: { current: number; total: number }) => {
+    const handleProgress = (progress: MetadataProgressPayload) => {
       console.log('[前端] 收到进度更新:', progress);
       setMetadataProgress(progress);
     };
@@ -492,7 +541,7 @@ export default function App() {
   // Handlers
   const handleConfirmSeries = (seriesId: string | null) => {
     // 找到用户选择的剧集对象,提取剧集名称
-    const selected = seriesId ? wizardData.seriesResults?.find((r: any) => r.id === seriesId) : null;
+    const selected = seriesId ? wizardData.seriesResults?.find((result) => result.id === seriesId) : null;
 
     window.ipcRenderer.send('scanner-confirm-response', {
       seriesId,
@@ -519,7 +568,7 @@ export default function App() {
 
   const handleConfirmEpisodes = (confirmed: boolean) => {
     if (!confirmed) {
-      window.ipcRenderer.send('scanner-episodes-confirm-response', { confirmed: false, options: {}, selectedIndices: [] });
+      window.ipcRenderer.send('scanner-episodes-confirm-response', { confirmed: false, selectedIndices: [] });
       setWizardWizardStage('idle'); setWizardData({});
     } else {
       setWizardWizardStage('executing');
@@ -533,7 +582,7 @@ export default function App() {
       window.ipcRenderer.send('scanner-confirm-response', { seriesId: null });
     }
     if (wizardStage === 'episodes') {
-      window.ipcRenderer.send('scanner-episodes-confirm-response', { confirmed: false, options: {}, selectedIndices: [] });
+      window.ipcRenderer.send('scanner-episodes-confirm-response', { confirmed: false, selectedIndices: [] });
     }
 
     setWizardWizardStage('idle');
@@ -563,8 +612,10 @@ export default function App() {
     setEditingMatchIndex(null);
 
     try {
+      const showId = item.tmdbId;
+      if (!showId) return;
       const metadata = await window.ipcRenderer.invoke('metadata:getEpisodeDetail', {
-        showId: item.tmdbId,
+        showId,
         season: editMatchValues.season,
         episode: editMatchValues.episode
       });
@@ -576,8 +627,8 @@ export default function App() {
         };
         setWizardData(prev => ({ ...prev, matches: updatedMatchesWithMeta }));
       }
-    } catch (e) {
-      console.error('Failed to fetch metadata for manual match:', e);
+    } catch (error) {
+      console.error('Failed to fetch metadata for manual match:', error);
     }
   };
 
@@ -658,7 +709,7 @@ export default function App() {
     setTimeout(() => handleFetchMetadataWithData(newMatches, wizardData.seriesId!), 100);
   };
 
-  const handleFetchMetadataWithData = async (matches: any[], seriesId: string) => {
+  const handleFetchMetadataWithData = async (matches: EpisodeMatchItem[], seriesId: string) => {
     if (!matches || !seriesId || fetchingMetadata) return;
 
     setFetchingMetadata(true);
@@ -710,14 +761,14 @@ export default function App() {
 
   const handleSmartIdentify = async () => {
     if (!wizardData.matches || smartIdentifying) return;
-    const unmatched = wizardData.matches.filter((item: any) => !item.match.success || item.match.source === 'unmatched');
+    const unmatched = wizardData.matches.filter((item) => !item.match.success || item.match.source === 'unmatched');
     if (unmatched.length === 0) return;
     setSmartIdentifying(true);
     try {
       const result = await window.ipcRenderer.invoke('scanner:smart-identify', { unmatchedFiles: unmatched });
       if (result.success) {
-        const newMatches = wizardData.matches.map((item: any) => {
-          const smartResult = result.results.find((r: any) => r.file.path === item.file.path);
+        const newMatches = wizardData.matches.map((item) => {
+          const smartResult = result.results.find((matchedItem) => matchedItem.file.path === item.file.path);
           return smartResult || item;
         });
         setWizardData(prev => ({ ...prev, matches: newMatches }));
@@ -764,7 +815,7 @@ export default function App() {
     return relativePath ? relativePath.split(/[\\/]/).filter(Boolean) : [];
   };
 
-  const loadDirectory = async (path: string, options?: { isBack?: boolean }) => {
+  const loadDirectory = useCallback(async (path: string, options?: { isBack?: boolean }) => {
     setLoadingFiles(true);
     setFileList([]);
     setSelectedPaths(new Set());
@@ -778,7 +829,7 @@ export default function App() {
     if (result.success) { setFileList(result.data); setCurrentPath(result.currentPath); }
     else { addLog(`无法加载目录: ${result.error}`, 'error'); }
     setLoadingFiles(false);
-  };
+  }, [addLog, currentPath, localPath, openListToken, openListUrl, sourceType]);
 
   const handleSourceTypeChange = (nextType: 'local' | 'openlist') => {
     if (nextType === sourceType) return;
@@ -874,13 +925,13 @@ export default function App() {
   };
 
   const handleAddRule = () => {
-    const newRule = { id: `rule_${Date.now()}`, pattern: '', type: 'tv' };
+    const newRule: RuleDefinition = { id: `rule_${Date.now()}`, pattern: '', type: 'tv' };
     setRules([...rules, newRule]);
   };
 
-  const handleUpdateRule = (idx: number, field: string, value: string) => {
+  const handleUpdateRule = (idx: number, field: keyof RuleDefinition, value: string) => {
     const newRules = [...rules];
-    (newRules[idx] as any)[field] = value;
+    newRules[idx] = { ...newRules[idx], [field]: value };
     setRules(newRules);
   };
 
@@ -920,21 +971,30 @@ export default function App() {
     setIsTestingOpenList(false);
   };
 
-  const handleShowEpisodeDetail = async (item: any) => {
-    if (!item.metadata || !item.tmdbId) return;
+  const handleShowEpisodeDetail = async (item: EpisodeMatchItem) => {
+    const showId = item.tmdbId;
+    if (!item.metadata || !showId) return;
     setLoadingDetail(true);
     setSelectedEpisodeDetail({ ...item.metadata, season: item.match.season, episode: item.match.episode });
     try {
-      const fullData = await window.ipcRenderer.invoke('metadata:getEpisodeDetail', { showId: item.tmdbId, season: item.match.season, episode: item.match.episode });
+      const fullData = await window.ipcRenderer.invoke('metadata:getEpisodeDetail', {
+        showId,
+        season: item.match.season ?? 1,
+        episode: item.match.episode ?? 1,
+      });
       if (fullData) {
         setSelectedEpisodeDetail({
           ...fullData,
           season: item.match.season,
           episode: item.match.episode,
-          overview: fullData.overview || item.metadata.overview || item.match.overview // Fallback to existing overview
+          overview: fullData.overview || item.metadata.overview
         });
       }
-    } catch (e) { console.error(e); } finally { setLoadingDetail(false); }
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoadingDetail(false);
+    }
   };
 
   const toggleSelection = (path: string, index: number, event?: { ctrlKey: boolean; shiftKey: boolean }) => {
@@ -994,19 +1054,6 @@ export default function App() {
     else setSelectedIndices([...selectedIndices, idx]);
   };
 
-  const refreshMedia = async (options?: { silent?: boolean }) => {
-    setIsRefreshingHistory(true);
-    try {
-      const allMedia = await window.ipcRenderer.invoke('media:getAll');
-      setMedia(Array.isArray(allMedia) ? allMedia : []);
-    } catch (e: any) {
-      if (!options?.silent) {
-        addLog(`刷新历史记录失败: ${e.message}`, 'error');
-      }
-    } finally {
-      setIsRefreshingHistory(false);
-    }
-  };
   const openUtilityPanel = async (panel: 'history' | 'logs') => {
     setActiveUtilityPanel(panel);
     if (panel === 'history') {
@@ -1015,7 +1062,7 @@ export default function App() {
   };
   const isConfigured = (sourceType === 'local' && localPath) || (sourceType === 'openlist' && openListUrl);
 
-  const runUpdateCheck = async (options?: { silent?: boolean }) => {
+  const runUpdateCheck = useCallback(async (options?: { silent?: boolean }) => {
     if (isCheckingUpdate) return;
 
     const silent = options?.silent ?? false;
@@ -1043,14 +1090,14 @@ export default function App() {
           addLog('当前已是最新版本', 'success');
         }
       }
-    } catch (e: any) {
+    } catch (error) {
       if (!silent) {
-        addLog(`检查更新出错: ${e.message}`, 'error');
+        addLog(`检查更新出错: ${getErrorMessage(error)}`, 'error');
       }
     } finally {
       setIsCheckingUpdate(false);
     }
-  };
+  }, [addLog, isCheckingUpdate]);
 
   const handleCheckUpdate = async () => {
     await runUpdateCheck();
@@ -1077,8 +1124,8 @@ export default function App() {
       } else {
         addLog(`下载更新失败: ${result?.error || '未知错误'}`, 'error');
       }
-    } catch (e: any) {
-      addLog(`更新失败: ${e.message}`, 'error');
+    } catch (error) {
+      addLog(`更新失败: ${getErrorMessage(error)}`, 'error');
     } finally {
       setIsDownloadingUpdate(false);
     }
@@ -1092,7 +1139,7 @@ export default function App() {
     }, 2500);
 
     return () => window.clearTimeout(timer);
-  }, [appVersion]);
+  }, [appVersion, runUpdateCheck]);
 
   useEffect(() => {
     if (activeTab === 'dashboard' && !isScanning) {
@@ -1103,7 +1150,7 @@ export default function App() {
         loadDirectory(nextPath);
       }
     }
-  }, [activeTab, sourceType, localPath, openListUrl, isScanning]);
+  }, [activeTab, currentPath, isScanning, loadDirectory, localPath, openListUrl, sourceType]);
 
   useEffect(() => {
     if (activeTab !== 'dashboard' && activeUtilityPanel) {
@@ -1114,7 +1161,7 @@ export default function App() {
   return (
     <div className="flex h-screen bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 overflow-hidden">
       {/* Title Bar */}
-      <div className="fixed top-0 left-0 right-0 h-8 z-[100] flex items-center justify-between bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800 select-none" style={{ WebkitAppRegion: 'drag' } as any}>
+      <div className="fixed top-0 left-0 right-0 h-8 z-[100] flex items-center justify-between bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800 select-none" style={dragRegionStyle}>
         <div className="px-3 flex items-center gap-2 text-[11px] font-bold text-slate-500 tracking-wider uppercase">
           <img
             src="./app-icon.png"
@@ -1127,14 +1174,14 @@ export default function App() {
             onClick={handleCheckUpdate}
             disabled={isCheckingUpdate}
             className="ml-1 px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-[9px] font-black text-slate-400 dark:text-slate-500 tracking-normal transition-colors cursor-pointer disabled:opacity-50"
-            style={{ WebkitAppRegion: 'no-drag' } as any}
+            style={noDragRegionStyle}
             title="点击检查更新"
           >
             {isCheckingUpdate ? "Checking..." : (appVersion ? `V${appVersion}` : '...')}
           </button>
         </div>
 
-        <div className="flex h-full items-center" style={{ WebkitAppRegion: 'no-drag' } as any}>
+        <div className="flex h-full items-center" style={noDragRegionStyle}>
           <button
             onClick={() => setActiveTab(activeTab === 'settings' ? 'dashboard' : 'settings')}
             className={clsx(
@@ -1586,7 +1633,7 @@ export default function App() {
                       </div>
                       <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-xl p-4 flex items-center justify-between">
                         <span className="text-sm font-bold">日志级别</span>
-                        <select value={logLevel} onChange={(e) => setLogLevel(e.target.value as any)} className="bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1 text-xs outline-none font-bold">
+                        <select value={logLevel} onChange={(e) => setLogLevel(e.target.value as LogLevel)} className="bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg px-2 py-1 text-xs outline-none font-bold">
                           <option value="debug">Debug (调试)</option>
                           <option value="info">Info (信息)</option>
                           <option value="warn">Warning (警告)</option>
@@ -1793,7 +1840,7 @@ export default function App() {
                 )}
                 {wizardData.seriesResults !== undefined && wizardData.seriesResults.length === 0 && <div className="text-center py-10 text-slate-400">未找到相关结果，请尝试其他关键词。</div>}
 
-                {wizardData.seriesResults && wizardData.seriesResults.map((item: any) => (
+                {wizardData.seriesResults && wizardData.seriesResults.map((item) => (
                   <div key={item.id} onClick={() => handleConfirmSeries(item.id)} className="flex gap-4 p-3 rounded-xl border hover:border-blue-500 cursor-pointer transition-all">
                     {item.poster ? <img src={item.poster} className="w-20 h-28 object-cover rounded-md" alt="" /> : <div className="w-20 h-28 bg-slate-100 rounded-md flex items-center justify-center"><File className="w-8 h-8 text-slate-400" /></div>}
                     <div className="flex-1 min-w-0"><h4 className="font-bold text-lg truncate">{item.title} ({item.year || 'N/A'})</h4><p className="text-xs text-slate-500 line-clamp-3 mt-1">{item.overview}</p></div>
@@ -1807,9 +1854,9 @@ export default function App() {
               <>
                 <div className="px-6 py-4 bg-slate-50 border-b border-slate-200">
                   <div className="flex flex-wrap gap-4">
-                    {[{ id: 'rename', label: '重命名' }, { id: 'writeNfo', label: '生成 NFO' }, { id: 'writePoster', label: '下载海报' }, { id: 'writeStill', label: '下载剧照' }].map(opt => (
+                    {batchOptionDefinitions.map((opt) => (
                       <label key={opt.id} className="flex items-center gap-2 cursor-pointer">
-                        <input type="checkbox" checked={(batchOptions as any)[opt.id]} onChange={() => toggleOption(opt.id as any)} className="w-4 h-4 rounded text-blue-600" />
+                        <input type="checkbox" checked={batchOptions[opt.id]} onChange={() => toggleOption(opt.id)} className="w-4 h-4 rounded text-blue-600" />
                         <span className="text-xs font-bold">{opt.label}</span>
                       </label>
                     ))}
@@ -1850,7 +1897,7 @@ export default function App() {
                   </div>
                 )}
                 {/* Smart Identify Button */}
-                {wizardData.matches && wizardData.matches.some((item: any) => !item.match.success || item.match.source === 'unmatched') && (
+                {wizardData.matches && wizardData.matches.some((item) => !item.match.success || item.match.source === 'unmatched') && (
                   <div className="px-6 py-3 bg-amber-50 dark:bg-amber-900/10 border-b border-amber-200 dark:border-amber-900/30">
                     <button
                       onClick={handleSmartIdentify}
@@ -1870,12 +1917,12 @@ export default function App() {
                       )}
                     </button>
                     <p className="text-xs text-slate-400 mt-2">
-                      使用 AI 识别正则匹配失败的文件（共 {wizardData.matches.filter((item: any) => !item.match.success || item.match.source === 'unmatched').length} 个）
+                      使用 AI 识别正则匹配失败的文件（共 {wizardData.matches.filter((item) => !item.match.success || item.match.source === 'unmatched').length} 个）
                     </p>
                   </div>
                 )}
                 {/* Fetch Metadata Button */}
-                {!metadataFetched && !fetchingMetadata && wizardData.matches && wizardData.matches.some((item: any) => !item.metadata) && (
+                {!metadataFetched && !fetchingMetadata && wizardData.matches && wizardData.matches.some((item) => !item.metadata) && (
                   <div className="px-6 py-3 bg-blue-50 dark:bg-blue-900/10 border-b border-blue-200 dark:border-blue-900/30">
                     <button
                       onClick={handleFetchMetadata}
@@ -1918,7 +1965,7 @@ export default function App() {
                   <table className="w-full text-left border-collapse">
                     <thead className="sticky top-0 bg-white border-b border-slate-200 text-[10px] font-bold text-slate-400 uppercase"><tr><th className="px-6 py-3 w-12"><input type="checkbox" checked={selectedIndices.length === wizardData.matches?.length} onChange={toggleSelectIndicesAll} /></th><th>预览</th><th className="w-24">识别结果</th><th>元数据</th></tr></thead>
                     <tbody className="divide-y divide-slate-200">
-                      {wizardData.matches?.map((item: any, idx: number) => {
+                      {wizardData.matches?.map((item, idx) => {
                         const fileExt = item.file.name.substring(item.file.name.lastIndexOf('.'));
                         // 根据总集数自动计算需要的位数（最少2位）
                         const episodeDigits = Math.max(2, String(item.match.totalEpisodes || 0).length);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -19,7 +19,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
 
 // Use contextBridge
 if (window.ipcRenderer) {
-  window.ipcRenderer.on('main-process-message', (_event, message) => {
+  window.ipcRenderer.on('main-process-message', (message: string) => {
     console.log(message)
   })
 }

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
+import type { LogType, SourceType } from '../../shared/types';
 
-export type LogType = 'info' | 'success' | 'error' | 'warn' | 'debug';
+export type { LogType };
 
 export interface ScrapedMediaRecord {
   id?: number;
@@ -19,19 +20,31 @@ export interface ScrapedMediaRecord {
   scraped_at: string;
 }
 
+interface AppConfigState {
+  tmdbKey: string;
+  openaiKey: string;
+  openaiBaseUrl: string;
+  openaiModel: string;
+  proxyUrl: string;
+  sourceType: SourceType;
+  localPath: string;
+  openListUrl: string;
+  openListToken: string;
+}
+
 interface AppState {
   // Config
   tmdbKey: string;
   openaiKey: string;
   openaiBaseUrl: string;
   openaiModel: string;
-  proxyUrl: string; // Added
+  proxyUrl: string;
 
   // Source Config
-  sourceType: 'local' | 'openlist';
+  sourceType: SourceType;
   localPath: string;
   openListUrl: string;
-  openListToken: string; // Changed from User/Pass
+  openListToken: string;
 
   // Scanner
   isScanning: boolean;
@@ -44,8 +57,8 @@ interface AppState {
   media: ScrapedMediaRecord[];
 
   // Actions
-  setConfig: (key: string, value: string) => void;
-  setVideoExtensions: (exts: string) => void; // Added
+  setConfig: <K extends keyof AppConfigState>(key: K, value: AppConfigState[K]) => void;
+  setVideoExtensions: (exts: string) => void;
   addLog: (message: string, type: LogType) => void;
   clearLogs: () => void;
   setScanning: (status: boolean) => void;
@@ -69,7 +82,11 @@ export const useAppStore = create<AppState>((set) => ({
   logs: [],
   media: [],
 
-  setConfig: (key, value) => set((state) => ({ ...state, [key]: value })),
+  setConfig: (key, value) =>
+    set((state) => ({
+      ...state,
+      [key]: value,
+    })),
   setVideoExtensions: (videoExtensions) => set({ videoExtensions }),
   addLog: (message, type) => set((state) => ({
     logs: [...state.logs, { message, type, timestamp: Date.now() }].slice(-100) // Keep last 100

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "electron"],
+  "include": ["src", "electron", "shared"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- add shared IPC and domain types for renderer/main process boundaries
- remove high-risk `any` usage across scanning, metadata, update, and renderer flows
- tighten fetch/openlist/tmdb error handling and preload typing

## Testing
- npm run lint
- npx tsc -p tsconfig.json --noEmit
- user manual validation of core app flows

Fixes #11