### PR TITLE
Automate Windows release builds and smoke test installers

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,134 @@
+name: Release Build
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  build-windows:
+    name: Build Windows Installer
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        shell: pwsh
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate release version
+        id: version
+        shell: pwsh
+        run: |
+          $packageVersion = node -p "require('./package.json').version"
+          $tagName = "${{ github.event.release.tag_name }}"
+
+          if ($tagName -ne "v$packageVersion") {
+            throw "Release tag $tagName does not match package.json version v$packageVersion."
+          }
+
+          "package_version=$packageVersion" >> $env:GITHUB_OUTPUT
+
+      - name: Build Windows release artifacts
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm run build -- --win --publish never
+
+      - name: Smoke test Windows installer
+        shell: pwsh
+        run: |
+          $installerPath = "release/${{ steps.version.outputs.package_version }}/OpenListScraper-Windows-${{ steps.version.outputs.package_version }}-Setup.exe"
+          $installDirectory = Join-Path $env:RUNNER_TEMP "OpenListScraper-smoke-${{ steps.version.outputs.package_version }}"
+          $installedExePath = Join-Path $installDirectory "OpenListScraper.exe"
+          $appProcess = $null
+
+          function Invoke-Cleanup {
+            param(
+              [string]$TargetDirectory,
+              [System.Diagnostics.Process]$ProcessToStop
+            )
+
+            if ($null -ne $ProcessToStop -and -not $ProcessToStop.HasExited) {
+              Stop-Process -Id $ProcessToStop.Id -Force
+              Start-Sleep -Seconds 2
+            }
+
+            if (-not (Test-Path $TargetDirectory)) {
+              return
+            }
+
+            $uninstaller = Get-ChildItem -Path $TargetDirectory -Filter "Uninstall *.exe" -File -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($null -ne $uninstaller) {
+              $uninstallProcess = Start-Process -FilePath $uninstaller.FullName -ArgumentList "/S" -Wait -PassThru
+              if ($uninstallProcess.ExitCode -ne 0) {
+                throw "Silent uninstall failed with exit code $($uninstallProcess.ExitCode)."
+              }
+            }
+
+            if (Test-Path $TargetDirectory) {
+              Remove-Item -Path $TargetDirectory -Recurse -Force
+            }
+          }
+
+          try {
+            if (Test-Path $installDirectory) {
+              Remove-Item -Path $installDirectory -Recurse -Force
+            }
+
+            $installProcess = Start-Process -FilePath $installerPath -ArgumentList "/S", "/D=$installDirectory" -Wait -PassThru
+            if ($installProcess.ExitCode -ne 0) {
+              throw "Silent install failed with exit code $($installProcess.ExitCode)."
+            }
+
+            if (-not (Test-Path $installedExePath)) {
+              throw "Installed executable not found at $installedExePath."
+            }
+
+            $appProcess = Start-Process -FilePath $installedExePath -PassThru
+
+            $deadline = (Get-Date).AddSeconds(12)
+            while ((Get-Date) -lt $deadline) {
+              Start-Sleep -Seconds 1
+
+              if ($appProcess.HasExited) {
+                throw "Installed app exited during smoke test with exit code $($appProcess.ExitCode)."
+              }
+            }
+          }
+          finally {
+            Invoke-Cleanup -TargetDirectory $installDirectory -ProcessToStop $appProcess
+          }
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          fail_on_unmatched_files: true
+          files: |
+            release/${{ steps.version.outputs.package_version }}/OpenListScraper-Windows-${{ steps.version.outputs.package_version }}-Setup.exe
+            release/${{ steps.version.outputs.package_version }}/OpenListScraper-Windows-${{ steps.version.outputs.package_version }}-Setup.exe.blockmap
+            release/${{ steps.version.outputs.package_version }}/latest.yml

--- a/README.md
+++ b/README.md
@@ -66,14 +66,40 @@ pnpm run rebuild:native
 
 ### 打包发布
 
-构建生产环境的安装包（支持 Windows/macOS/Linux）：
+构建生产环境安装包：
 
 ```bash
 pnpm build
 ```
 打包后的文件将位于 `release/<version>/` 目录中。
 
+当前仓库的 `electron-builder` 配置里已经预留了 Windows、macOS、Linux 的 target，但目前仓库内实际验证和发布流程仅覆盖 Windows。macOS / Linux 如需对外宣称支持，建议先分别完成对应平台的本地验证、安装器验证和 CI 发布链路。
+
 发布前的安装器回归检查请参考 [docs/installer-qa-checklist.md](docs/installer-qa-checklist.md)。
+
+### GitHub Actions 自动发布
+
+仓库内置了 GitHub Actions 工作流 [`.github/workflows/release-build.yml`](.github/workflows/release-build.yml)，用于在 GitHub Release 发布后自动构建并上传 Windows 安装包。
+
+当前行为如下：
+
+1.  发布一个已发布状态的 GitHub Release。
+2.  Release 的 Tag 必须与 `package.json` 版本一致，例如 `v1.3.1` 对应 `"version": "1.3.1"`。
+3.  工作流会在 `windows-latest` 上执行 `pnpm install --frozen-lockfile` 和 `pnpm run build -- --win --publish never`。
+4.  构建完成后，工作流会执行一次最小自动验证：静默安装安装包、检查 `OpenListScraper.exe` 是否落盘，并尝试启动已安装应用做冒烟测试。
+5.  自动验证通过后，工作流会把以下文件上传到对应的 GitHub Release：
+    *   `OpenListScraper-Windows-<version>-Setup.exe`
+    *   `OpenListScraper-Windows-<version>-Setup.exe.blockmap`
+    *   `latest.yml`
+
+当前自动化不要求额外的 GitHub Secret，上传资产使用 Actions 内置的 `GITHUB_TOKEN` 即可。
+
+注意事项：
+
+*   目前工作流只自动构建 Windows 安装包，后续如需扩展 macOS/Linux，可在此工作流基础上增加矩阵构建。
+*   当前发布产物仍为未签名安装包；如果后续接入代码签名，需要额外配置如 `CSC_LINK`、`CSC_KEY_PASSWORD` 等 Secret。
+*   如果 Release Tag 与 `package.json` 版本不一致，工作流会直接失败，避免把错误版本的资产上传到 Release。
+*   当前自动验证只覆盖“能安装并至少成功启动”的基础冒烟测试，不能替代 [docs/installer-qa-checklist.md](docs/installer-qa-checklist.md) 中的完整人工安装器回归。
 
 ### 自动更新发布要求
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds Windows release artifacts when a GitHub Release is published
- verify the release tag matches package.json before building and uploading assets
- smoke test the generated installer by silently installing it, checking the installed exe, and launching the app before upload
- document the current Windows-only release automation scope in the README

## Testing
- npm run lint
- npm run build -- --win --publish never
- manual local smoke test using the generated installer: silent install, verify OpenListScraper.exe exists, launch for 12 seconds, then uninstall

Fixes #14