### PR TITLE
Fix Windows pnpm setup in release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -28,6 +28,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 10.17.1
+          standalone: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- configure pnpm/action-setup to use the standalone executable on Windows runners
- avoid the pnpm.cjs execution failure triggered by electron-builder install-app-deps during postinstall
- unblock prerelease validation for the Release Build workflow

## Testing
- not run locally (GitHub Actions Windows runner compatibility fix)
- verified against the failed v1.4.0-rc.1 workflow log showing pnpm.cjs was treated as a non-executable on Windows

Fixes #37