### PR TITLE
Stabilize release workflow smoke test

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -59,17 +59,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run build -- --win --publish never
 
-      - name: Smoke test Windows installer
+      - name: Validate release artifacts
         shell: pwsh
         run: |
           $installerPath = "release/${{ steps.version.outputs.package_version }}/OpenListScraper-Windows-${{ steps.version.outputs.package_version }}-Setup.exe"
-          $installDirectory = Join-Path $env:RUNNER_TEMP "OpenListScraper-smoke-${{ steps.version.outputs.package_version }}"
-          $installedExePath = Join-Path $installDirectory "OpenListScraper.exe"
+          $blockmapPath = "release/${{ steps.version.outputs.package_version }}/OpenListScraper-Windows-${{ steps.version.outputs.package_version }}-Setup.exe.blockmap"
+          $latestYmlPath = "release/${{ steps.version.outputs.package_version }}/latest.yml"
+          $unpackedExePath = "release/${{ steps.version.outputs.package_version }}/win-unpacked/OpenListScraper.exe"
           $appProcess = $null
 
-          function Invoke-Cleanup {
+          function Stop-AppProcess {
             param(
-              [string]$TargetDirectory,
               [System.Diagnostics.Process]$ProcessToStop
             )
 
@@ -77,51 +77,28 @@ jobs:
               Stop-Process -Id $ProcessToStop.Id -Force
               Start-Sleep -Seconds 2
             }
-
-            if (-not (Test-Path $TargetDirectory)) {
-              return
-            }
-
-            $uninstaller = Get-ChildItem -Path $TargetDirectory -Filter "Uninstall *.exe" -File -ErrorAction SilentlyContinue | Select-Object -First 1
-            if ($null -ne $uninstaller) {
-              $uninstallProcess = Start-Process -FilePath $uninstaller.FullName -ArgumentList "/S" -Wait -PassThru
-              if ($uninstallProcess.ExitCode -ne 0) {
-                throw "Silent uninstall failed with exit code $($uninstallProcess.ExitCode)."
-              }
-            }
-
-            if (Test-Path $TargetDirectory) {
-              Remove-Item -Path $TargetDirectory -Recurse -Force
-            }
           }
 
           try {
-            if (Test-Path $installDirectory) {
-              Remove-Item -Path $installDirectory -Recurse -Force
+            foreach ($requiredPath in @($installerPath, $blockmapPath, $latestYmlPath, $unpackedExePath)) {
+              if (-not (Test-Path $requiredPath)) {
+                throw "Required release artifact not found at $requiredPath."
+              }
             }
 
-            $installProcess = Start-Process -FilePath $installerPath -ArgumentList "/S", "/D=$installDirectory" -Wait -PassThru
-            if ($installProcess.ExitCode -ne 0) {
-              throw "Silent install failed with exit code $($installProcess.ExitCode)."
-            }
-
-            if (-not (Test-Path $installedExePath)) {
-              throw "Installed executable not found at $installedExePath."
-            }
-
-            $appProcess = Start-Process -FilePath $installedExePath -PassThru
+            $appProcess = Start-Process -FilePath $unpackedExePath -PassThru
 
             $deadline = (Get-Date).AddSeconds(12)
             while ((Get-Date) -lt $deadline) {
               Start-Sleep -Seconds 1
 
               if ($appProcess.HasExited) {
-                throw "Installed app exited during smoke test with exit code $($appProcess.ExitCode)."
+                throw "Unpacked app exited during smoke test with exit code $($appProcess.ExitCode)."
               }
             }
           }
           finally {
-            Invoke-Cleanup -TargetDirectory $installDirectory -ProcessToStop $appProcess
+            Stop-AppProcess -ProcessToStop $appProcess
           }
 
       - name: Upload release assets

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pnpm build
 1.  发布一个已发布状态的 GitHub Release。
 2.  Release 的 Tag 必须与 `package.json` 版本一致，例如 `v1.3.1` 对应 `"version": "1.3.1"`。
 3.  工作流会在 `windows-latest` 上执行 `pnpm install --frozen-lockfile` 和 `pnpm run build -- --win --publish never`。
-4.  构建完成后，工作流会执行一次最小自动验证：静默安装安装包、检查 `OpenListScraper.exe` 是否落盘，并尝试启动已安装应用做冒烟测试。
+4.  构建完成后，工作流会执行一次最小自动验证：检查 `Setup.exe`、`.blockmap`、`latest.yml` 是否生成，并尝试启动 `win-unpacked/OpenListScraper.exe` 做冒烟测试。
 5.  自动验证通过后，工作流会把以下文件上传到对应的 GitHub Release：
     *   `OpenListScraper-Windows-<version>-Setup.exe`
     *   `OpenListScraper-Windows-<version>-Setup.exe.blockmap`
@@ -99,7 +99,7 @@ pnpm build
 *   目前工作流只自动构建 Windows 安装包，后续如需扩展 macOS/Linux，可在此工作流基础上增加矩阵构建。
 *   当前发布产物仍为未签名安装包；如果后续接入代码签名，需要额外配置如 `CSC_LINK`、`CSC_KEY_PASSWORD` 等 Secret。
 *   如果 Release Tag 与 `package.json` 版本不一致，工作流会直接失败，避免把错误版本的资产上传到 Release。
-*   当前自动验证只覆盖“能安装并至少成功启动”的基础冒烟测试，不能替代 [docs/installer-qa-checklist.md](docs/installer-qa-checklist.md) 中的完整人工安装器回归。
+*   当前自动验证只覆盖“发布产物已生成，且未打包的 Windows 应用至少能成功启动”的基础冒烟测试，不能替代 [docs/installer-qa-checklist.md](docs/installer-qa-checklist.md) 中的完整人工安装器回归。
 
 ### 自动更新发布要求
 


### PR DESCRIPTION
## Summary
- replace the installer silent-install smoke test with release artifact presence checks
- smoke test the generated win-unpacked OpenListScraper.exe instead of running the NSIS installer on GitHub-hosted Windows runners
- update the README to match the revised CI validation scope

## Testing
- local win-unpacked smoke test: launch release/1.3.1/win-unpacked/OpenListScraper.exe for 12 seconds and confirm it stays alive

Fixes #40