### PR TITLE
Bump version to 1.4.0-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "一款现代化的媒体文件整理与元数据刮削工具",
   "author": "Landon Li",
   "private": true,
-  "version": "1.4.0-rc.2",
+  "version": "1.4.0-rc.3",
   "type": "module",
   "packageManager": "pnpm@10.17.1",
   "scripts": {


### PR DESCRIPTION
## Summary
- bump package.json version from 1.4.0-rc.2 to 1.4.0-rc.3
- prepare the next prerelease tag after stabilizing the Windows release workflow smoke test

## Testing
- not run (version bump only)

Related to #40