### PR TITLE
Fix updater-installed app startup bindings fallback

### DIFF
--- a/electron/services/DatabaseService.ts
+++ b/electron/services/DatabaseService.ts
@@ -11,6 +11,7 @@ type BetterSqliteConstructor = new (
 
 const require = createRequire(import.meta.url);
 const BETTER_SQLITE_NATIVE_ERROR_PATTERNS = [
+  /Cannot find module ['"]bindings['"]/i,
   /Could not locate the bindings file/i,
   /was compiled against a different Node\.js version/i,
   /NODE_MODULE_VERSION/i,
@@ -58,6 +59,51 @@ function loadBetterSqlite(): BetterSqliteConstructor {
       | { default: BetterSqliteConstructor };
 
     return typeof loaded === 'function' ? loaded : loaded.default;
+  } catch (error) {
+    const originalMessage = error instanceof Error ? error.message : String(error);
+
+    if (/Cannot find module ['"]bindings['"]/i.test(originalMessage)) {
+      return loadBetterSqliteWithoutBindings();
+    }
+
+    throw normalizeBetterSqliteError(error);
+  }
+}
+
+function getBetterSqliteNativeBindingPath(): string {
+  const betterSqlitePackagePath = require.resolve('better-sqlite3/package.json');
+  const betterSqliteRoot = path.dirname(betterSqlitePackagePath);
+  const asarUnpackedRoot = betterSqliteRoot.replace(/app\.asar/i, 'app.asar.unpacked');
+  const candidates = [
+    path.join(asarUnpackedRoot, 'build', 'Release', 'better_sqlite3.node'),
+    path.join(betterSqliteRoot, 'build', 'Release', 'better_sqlite3.node'),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error([
+    '未找到 better-sqlite3 的原生模块文件。',
+    ...candidates.map((candidate) => `- ${candidate}`),
+  ].join('\n'));
+}
+
+function loadBetterSqliteWithoutBindings(): BetterSqliteConstructor {
+  try {
+    const loaded = require('better-sqlite3/lib/database.js') as BetterSqliteConstructor;
+    const nativeBinding = getBetterSqliteNativeBindingPath();
+
+    return class BetterSqliteWithNativeBinding {
+      constructor(filename: string, options?: Record<string, unknown>) {
+        return new loaded(filename, {
+          ...options,
+          nativeBinding,
+        });
+      }
+    } as unknown as BetterSqliteConstructor;
   } catch (error) {
     throw normalizeBetterSqliteError(error);
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "一款现代化的媒体文件整理与元数据刮削工具",
   "author": "Landon Li",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "packageManager": "pnpm@10.17.1",
   "scripts": {


### PR DESCRIPTION
## Summary
- add a startup fallback for `better-sqlite3` when the packaged app cannot resolve the `bindings` module after an in-app update
- resolve the native `better_sqlite3.node` binary directly so updater-installed builds can still initialize the local database
- bump the app version to `1.4.1` for the hotfix release

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- smoke-launched `release/1.4.1/win-unpacked/OpenListScraper.exe`

Fixes #44
