### PR TITLE
Fix release validation PowerShell parser error

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -106,7 +106,7 @@ jobs:
 
             if ($missingPackagedEntries.Length -gt 0) {
               throw @(
-                "Packaged runtime dependencies are missing from $appAsarPath:"
+                "Packaged runtime dependencies are missing from ${appAsarPath}:"
                 $missingPackagedEntries | ForEach-Object { "- $_" }
               ) -join "`n"
             }


### PR DESCRIPTION
## Summary
- fix the PowerShell string interpolation in the release validation workflow step
- preserve the packaged dependency validation while avoiding parser failures before asset upload

## Testing
- evaluated the validation message expression locally in PowerShell using the same interpolation pattern
- confirmed the generated message renders without the previous parser error

Fixes #52