### PR TITLE
Enable history entries to jump back to explorer locations

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, nativeImage } from 'electron';
+import { app, BrowserWindow, ipcMain, dialog, nativeImage, shell } from 'electron';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import ElectronStore from 'electron-store';
@@ -229,6 +229,16 @@ function registerIpcHandlers() {
     if (!win) return null;
     const { canceled, filePaths } = await dialog.showOpenDialog(win, { properties: ['openDirectory'] });
     return canceled ? null : filePaths[0];
+  });
+
+  ipcMain.handle('system:openExternal', async (_, url: string) => {
+    if (!/^https?:\/\//i.test(url)) return false;
+    try {
+      await shell.openExternal(url);
+      return true;
+    } catch {
+      return false;
+    }
   });
 
   ipcMain.on('window:minimize', () => win?.minimize());

--- a/electron/services/DatabaseService.ts
+++ b/electron/services/DatabaseService.ts
@@ -140,6 +140,7 @@ export interface ScrapedMedia {
   id?: number;
   filePath: string;
   sourceId: string;
+  sourceType?: 'local' | 'openlist';
   seriesName: string;
   season: number;
   episode: number;
@@ -175,6 +176,7 @@ export class DatabaseService {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         file_path TEXT NOT NULL,
         source_id TEXT NOT NULL,
+        source_type TEXT,
         series_name TEXT,
         season INTEGER,
         episode INTEGER,
@@ -200,18 +202,22 @@ export class DatabaseService {
     if (!columns.includes('runtime')) {
       this.db.exec("ALTER TABLE scraped_media ADD COLUMN runtime INTEGER");
     }
+    if (!columns.includes('source_type')) {
+      this.db.exec("ALTER TABLE scraped_media ADD COLUMN source_type TEXT");
+    }
   }
 
   saveMedia(media: Omit<ScrapedMedia, 'id' | 'scrapedAt'>) {
     const stmt = this.db.prepare(`
       INSERT INTO scraped_media (
-        file_path, source_id, series_name, season, episode, 
+        file_path, source_id, source_type, series_name, season, episode,
         tmdb_id, episode_title, overview, poster, still, air_date, runtime
       ) VALUES (
-        @filePath, @sourceId, @seriesName, @season, @episode,
+        @filePath, @sourceId, @sourceType, @seriesName, @season, @episode,
         @tmdbId, @episodeTitle, @overview, @poster, @still, @airDate, @runtime
       )
       ON CONFLICT(source_id, file_path) DO UPDATE SET
+        source_type = excluded.source_type,
         series_name = excluded.series_name,
         season = excluded.season,
         episode = excluded.episode,

--- a/electron/services/ScannerService.ts
+++ b/electron/services/ScannerService.ts
@@ -591,6 +591,7 @@ export class ScannerService {
       this.dbService.saveMedia({
         filePath: item.file.path,
         sourceId: source.id,
+        sourceType: source.type === 'openlist' ? 'openlist' : 'local',
         seriesName,
         season: item.match.mediaType === 'movie' ? 0 : (item.match.season ?? 1),
         episode: item.match.mediaType === 'movie' ? 0 : (item.match.episode ?? 1),

--- a/shared/ipc.ts
+++ b/shared/ipc.ts
@@ -190,6 +190,7 @@ export interface WindowIpcRenderer {
   invoke(channel: 'scanner:scan-selected', request: ScanSelectedRequest): Promise<AsyncResult<Record<string, never>>>;
   invoke(channel: 'scanner:smart-identify', request: SmartIdentifyRequest): Promise<SmartIdentifyResponse>;
   invoke(channel: 'scanner:start', request: ScanSourceRequest): Promise<AsyncResult<Record<string, never>>>;
+  invoke(channel: 'system:openExternal', url: string): Promise<boolean>;
   invoke(channel: 'tmdb:test', token: string): Promise<AsyncResult<Record<string, never>>>;
   invoke(channel: 'update:check'): Promise<CheckUpdateResult>;
   invoke(channel: 'update:download'): Promise<DownloadUpdateResult>;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { useAppStore, LogType, ScrapedMediaRecord } from './stores/appStore';
-import { Settings, Database, Globe, Play, Eye, EyeOff, CheckCircle2, AlertCircle, RefreshCw, Save, ArrowRight, Minus, Square, X, Folder, Network, Zap, File, Clapperboard, ChevronUp, ChevronDown, LayoutGrid, List, Wand2, Sun, Moon, ArrowLeft, CornerLeftUp, Check, Calendar, Clock, Trash2, Download, Sparkles } from 'lucide-react';
+import { Settings, Database, Globe, Play, Eye, EyeOff, CheckCircle2, AlertCircle, RefreshCw, Save, ArrowRight, Minus, Square, X, Folder, Network, Zap, File, Clapperboard, ChevronUp, ChevronDown, LayoutGrid, List, Wand2, Sun, Moon, ArrowLeft, CornerLeftUp, Check, Calendar, Clock, Trash2, Download, Sparkles, Copy, ExternalLink } from 'lucide-react';
 import clsx from 'clsx';
 import type {
   ScannerRequireConfirmationPayload,
@@ -120,6 +120,39 @@ const basename = (input: string) => {
   return normalized.split('/').filter(Boolean).pop() || input;
 };
 
+const isAbsoluteLocalPath = (value: string) => /^[A-Za-z]:[\\/]/.test(value) || value.startsWith('\\\\');
+
+const resolveHistoryPath = (rawPath: string, sourceType: 'local' | 'openlist', localRootPath: string) => {
+  if (sourceType === 'openlist') {
+    const normalized = rawPath.replace(/\\/g, '/');
+    return normalized.startsWith('/') ? normalized : `/${normalized}`;
+  }
+
+  if (isAbsoluteLocalPath(rawPath)) return rawPath;
+  if (!localRootPath) return rawPath;
+
+  const normalizedRoot = localRootPath.replace(/[\\/]+$/, '');
+  const normalizedRelative = rawPath.replace(/^[/\\]+/, '');
+  return `${normalizedRoot}\\${normalizedRelative.replace(/[\\/]+/g, '\\')}`;
+};
+
+const getHistoryParentPath = (targetPath: string, sourceType: 'local' | 'openlist') => {
+  if (sourceType === 'openlist') {
+    const normalized = targetPath.replace(/\\/g, '/').replace(/\/+$/, '');
+    if (!normalized || normalized === '/') return '/';
+    const index = normalized.lastIndexOf('/');
+    if (index <= 0) return '/';
+    return normalized.slice(0, index);
+  }
+
+  const normalized = targetPath.replace(/[\\/]+$/, '');
+  const index = Math.max(normalized.lastIndexOf('\\'), normalized.lastIndexOf('/'));
+  if (index < 0) return normalized;
+  const parent = normalized.slice(0, index);
+  if (/^[A-Za-z]:$/.test(parent)) return `${parent}\\`;
+  return parent;
+};
+
 const formatFileSize = (size?: number) => {
   if (!size || size <= 0) return '--';
   if (size < 1024) return `${size} B`;
@@ -211,14 +244,47 @@ const LogItem = ({ log }: { log: { message: string, type: LogType, timestamp: nu
   );
 };
 
-const MediaHistoryItem = ({ item }: { item: ScrapedMediaRecord }) => {
-  const imageUrl = item.still || item.poster;
-  const episodeCode = `S${String(item.season ?? 0).padStart(2, '0')}E${String(item.episode ?? 0).padStart(2, '0')}`;
+const MediaHistoryItem = ({
+  item,
+  onNavigate,
+  isNavigating,
+}: {
+  item: ScrapedMediaRecord;
+  onNavigate: (item: ScrapedMediaRecord) => void;
+  isNavigating: boolean;
+}) => {
+  const isMovie = (item.season ?? 0) === 0 && (item.episode ?? 0) === 0;
+  const imageUrl = isMovie ? (item.poster || item.still) : (item.still || item.poster);
+  const episodeCode = isMovie
+    ? 'Movie'
+    : `S${String(item.season ?? 0).padStart(2, '0')}E${String(item.episode ?? 0).padStart(2, '0')}`;
+  const tmdbUrl = item.tmdb_id
+    ? `https://www.themoviedb.org/${isMovie ? 'movie' : 'tv'}/${item.tmdb_id}`
+    : null;
 
   return (
-    <article className="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-900/80 shadow-sm overflow-hidden">
+    <article
+      role="button"
+      tabIndex={0}
+      onClick={() => !isNavigating && onNavigate(item)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          if (!isNavigating) onNavigate(item);
+        }
+      }}
+      className={clsx(
+        "group rounded-2xl border bg-white/90 dark:bg-slate-900/80 shadow-sm overflow-hidden transition-all",
+        isNavigating
+          ? "border-blue-300 dark:border-blue-700 ring-1 ring-blue-300/50 dark:ring-blue-700/50"
+          : "border-slate-200 dark:border-slate-800 hover:border-blue-200 dark:hover:border-blue-800 hover:shadow-md cursor-pointer"
+      )}
+    >
       <div className="flex gap-3 p-3">
-        <div className="w-24 h-16 shrink-0 rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 flex items-center justify-center">
+        <div className={clsx(
+          "shrink-0 rounded-xl overflow-hidden bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 flex items-center justify-center",
+          isMovie ? "w-16 h-24" : "w-24 h-16"
+        )}>
           {imageUrl ? (
             <img src={imageUrl} alt={item.episode_title || item.series_name || 'Scraped media'} className="w-full h-full object-cover" />
           ) : (
@@ -232,9 +298,35 @@ const MediaHistoryItem = ({ item }: { item: ScrapedMediaRecord }) => {
               <p className="text-[11px] font-black uppercase tracking-[0.18em] text-blue-600 dark:text-blue-400">{episodeCode}</p>
               <h3 className="text-sm font-bold text-slate-900 dark:text-slate-100 truncate">{item.series_name || '未命名剧集'}</h3>
             </div>
-            <span className="shrink-0 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400 px-2 py-1 text-[10px] font-bold">
-              已刮削
-            </span>
+            <div className="shrink-0 flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  navigator.clipboard.writeText(item.file_path);
+                }}
+                className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 h-7 w-7 rounded-lg border border-slate-200 dark:border-slate-700 bg-white/90 dark:bg-slate-900/90 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-all flex items-center justify-center"
+                title="复制路径"
+              >
+                <Copy className="w-3.5 h-3.5" />
+              </button>
+              {tmdbUrl && (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    window.open(tmdbUrl, '_blank', 'noopener,noreferrer');
+                  }}
+                  className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 h-7 w-7 rounded-lg border border-slate-200 dark:border-slate-700 bg-white/90 dark:bg-slate-900/90 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-all flex items-center justify-center"
+                  title="打开 TMDB 页面"
+                >
+                  <ExternalLink className="w-3.5 h-3.5" />
+                </button>
+              )}
+              <span className="rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-400 px-2 py-1 text-[10px] font-bold">
+                已刮削
+              </span>
+            </div>
           </div>
 
           <p className="text-xs font-medium text-slate-600 dark:text-slate-300 truncate">
@@ -249,16 +341,11 @@ const MediaHistoryItem = ({ item }: { item: ScrapedMediaRecord }) => {
         </div>
       </div>
 
-      <button
-        type="button"
-        onClick={() => navigator.clipboard.writeText(item.file_path)}
-        className="w-full border-t border-slate-100 dark:border-slate-800 px-3 py-2 text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/80"
-        title="点击复制文件路径"
-      >
+      <div className="border-t border-slate-100 dark:border-slate-800 px-3 py-2">
         <div className="text-[10px] font-black uppercase tracking-[0.18em] text-slate-400">文件路径</div>
         <div className="mt-1 text-xs text-slate-600 dark:text-slate-300 truncate">{basename(item.file_path)}</div>
         <div className="mt-0.5 text-[11px] text-slate-400 truncate">{item.file_path}</div>
-      </button>
+      </div>
     </article>
   );
 };
@@ -399,6 +486,7 @@ export default function App() {
   const [downloadProgress, setDownloadProgress] = useState(0);
   const [isUpdateReady, setIsUpdateReady] = useState(false);
   const [isRefreshingHistory, setIsRefreshingHistory] = useState(false);
+  const [navigatingHistoryPath, setNavigatingHistoryPath] = useState<string | null>(null);
   const updateCheckInFlightRef = useRef(false);
 
   const refreshMedia = useCallback(async (options?: { silent?: boolean }) => {
@@ -879,23 +967,42 @@ export default function App() {
     return relativePath ? relativePath.split(/[\\/]/).filter(Boolean) : [];
   };
 
-  const loadDirectory = useCallback(async (path: string, options?: { isBack?: boolean }) => {
+  const loadDirectoryForSource = useCallback(async (
+    targetSourceType: 'local' | 'openlist',
+    path: string,
+    options?: { isBack?: boolean; silentError?: boolean },
+  ) => {
     setLoadingFiles(true);
     setFileList([]);
     setSelectedPaths(new Set());
     setLastClickedIndex(null);
 
-    if (!options?.isBack && currentPath) {
+    if (!options?.isBack && currentPath && targetSourceType === sourceType) {
       setNavHistory(prev => [...prev, currentPath]);
     }
 
-    const result = await window.ipcRenderer.invoke('explorer:list', { type: sourceType, path, config: { localPath, openListUrl, openListToken } });
-    if (result.success) { setFileList(result.data); setCurrentPath(result.currentPath); }
-    else { addLog(`无法加载目录: ${result.error}`, 'error'); }
+    const result = await window.ipcRenderer.invoke('explorer:list', {
+      type: targetSourceType,
+      path,
+      config: { localPath, openListUrl, openListToken },
+    });
+
+    if (result.success) {
+      setFileList(result.data);
+      setCurrentPath(result.currentPath);
+    } else if (!options?.silentError) {
+      addLog(`无法加载目录: ${result.error}`, 'error');
+    }
+
     setLoadingFiles(false);
+    return result;
   }, [addLog, currentPath, localPath, openListToken, openListUrl, sourceType]);
 
-  const handleSourceTypeChange = (nextType: 'local' | 'openlist') => {
+  const loadDirectory = useCallback(async (path: string, options?: { isBack?: boolean; silentError?: boolean }) => {
+    return loadDirectoryForSource(sourceType, path, options);
+  }, [loadDirectoryForSource, sourceType]);
+
+  const handleSourceTypeChange = useCallback((nextType: 'local' | 'openlist') => {
     if (nextType === sourceType) return;
 
     setConfig('sourceType', nextType);
@@ -904,7 +1011,63 @@ export default function App() {
     setFileList([]);
     setSelectedPaths(new Set());
     setLastClickedIndex(null);
-  };
+  }, [setConfig, sourceType]);
+
+  const handleOpenHistoryItem = useCallback(async (item: ScrapedMediaRecord) => {
+    const inferredSourceType = item.source_type === 'local' || item.source_type === 'openlist'
+      ? item.source_type
+      : (item.file_path.startsWith('/') ? 'openlist' : 'local');
+
+    if (inferredSourceType === 'local' && !localPath) {
+      addLog('无法从历史记录定位：本地路径未配置。', 'warn');
+      return;
+    }
+    if (inferredSourceType === 'openlist' && !openListUrl) {
+      addLog('无法从历史记录定位：OpenList 未配置。', 'warn');
+      return;
+    }
+
+    const resolvedPath = resolveHistoryPath(item.file_path, inferredSourceType, localPath);
+    setNavigatingHistoryPath(item.file_path);
+
+    try {
+      if (sourceType !== inferredSourceType) {
+        handleSourceTypeChange(inferredSourceType);
+      }
+
+      const tryDirectory = await loadDirectoryForSource(inferredSourceType, resolvedPath, { silentError: true });
+      if (tryDirectory.success) {
+        setActiveUtilityPanel(null);
+        addLog(`已从历史记录打开目录: ${resolvedPath}`, 'info');
+        return;
+      }
+
+      const parentPath = getHistoryParentPath(resolvedPath, inferredSourceType);
+      const tryParent = await loadDirectoryForSource(inferredSourceType, parentPath, { silentError: true });
+      if (!tryParent.success) {
+        addLog(`历史记录目标不可访问: ${item.file_path}`, 'warn');
+        return;
+      }
+
+      const normalizedTargetPath = resolvedPath.toLowerCase();
+      const targetFileIndex = tryParent.data.findIndex((entry) =>
+        !entry.isDir && entry.path.toLowerCase() === normalizedTargetPath,
+      );
+
+      if (targetFileIndex < 0) {
+        addLog(`历史记录中的文件已不存在: ${item.file_path}`, 'warn');
+        return;
+      }
+
+      const targetFile = tryParent.data[targetFileIndex];
+      setSelectedPaths(new Set([targetFile.path]));
+      setLastClickedIndex(targetFileIndex);
+      setActiveUtilityPanel(null);
+      addLog(`已从历史记录定位到文件: ${basename(targetFile.path)}`, 'success');
+    } finally {
+      setNavigatingHistoryPath(null);
+    }
+  }, [addLog, handleSourceTypeChange, loadDirectoryForSource, localPath, openListUrl, sourceType]);
 
   const handleGoBack = () => {
     if (navHistory.length === 0) return;
@@ -1680,7 +1843,12 @@ export default function App() {
                 </div>
               ) : (
                 media.map((item, index) => (
-                  <MediaHistoryItem key={item.id ?? `${item.file_path}-${index}`} item={item} />
+                  <MediaHistoryItem
+                    key={item.id ?? `${item.file_path}-${index}`}
+                    item={item}
+                    onNavigate={handleOpenHistoryItem}
+                    isNavigating={navigatingHistoryPath === item.file_path}
+                  />
                 ))
               )}
             </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -315,7 +315,7 @@ const MediaHistoryItem = ({
                   type="button"
                   onClick={(event) => {
                     event.stopPropagation();
-                    window.open(tmdbUrl, '_blank', 'noopener,noreferrer');
+                    void window.ipcRenderer.invoke('system:openExternal', tmdbUrl);
                   }}
                   className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 h-7 w-7 rounded-lg border border-slate-200 dark:border-slate-700 bg-white/90 dark:bg-slate-900/90 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-all flex items-center justify-center"
                   title="打开 TMDB 页面"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -259,7 +259,15 @@ const MediaHistoryItem = ({
     ? 'Movie'
     : `S${String(item.season ?? 0).padStart(2, '0')}E${String(item.episode ?? 0).padStart(2, '0')}`;
   const tmdbUrl = item.tmdb_id
-    ? `https://www.themoviedb.org/${isMovie ? 'movie' : 'tv'}/${item.tmdb_id}`
+    ? (
+        isMovie
+          ? `https://www.themoviedb.org/movie/${item.tmdb_id}`
+          : (
+              item.season && item.episode
+                ? `https://www.themoviedb.org/tv/${item.tmdb_id}/season/${item.season}/episode/${item.episode}`
+                : `https://www.themoviedb.org/tv/${item.tmdb_id}`
+            )
+      )
     : null;
 
   return (

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -7,6 +7,7 @@ export interface ScrapedMediaRecord {
   id?: number;
   file_path: string;
   source_id: string;
+  source_type?: SourceType;
   series_name?: string;
   season?: number;
   episode?: number;


### PR DESCRIPTION
## Summary
- add history-card primary interaction: click card to navigate back to the corresponding explorer location
- support cross-source jump by switching between local/OpenList when needed
- for file records, open parent directory and auto-select the target file; handle missing targets with clear logs
- persist source_type in scraped history to improve source routing reliability
- redesign history card actions to be lower-visual-weight and add TMDB quick-link action
- open TMDB links in system default browser, with TV items deep-linking to season/episode pages

## Testing
- npm run lint

Fixes #20