### PR TITLE
Fix season-folder title misdetection and allow series reselect in review

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -12,6 +12,7 @@ import type {
   OpenListTestRequest,
   ScanSelectedRequest,
   ScanSourceRequest,
+  SeriesSearchRequest,
   SmartIdentifyRequest,
 } from '../shared/ipc';
 import type {
@@ -346,6 +347,19 @@ function registerIpcHandlers() {
   ipcMain.handle('media:getAll', () => dbService.getAllMedia());
   ipcMain.handle('metadata:getEpisodeDetail', async (_, { showId, season, episode }) => {
     return await metadataProvider.getEpisodeDetails(showId, season, episode);
+  });
+
+  ipcMain.handle('metadata:searchSeries', async (_, { query, searchMode }: SeriesSearchRequest) => {
+    try {
+      const trimmed = query?.trim();
+      if (!trimmed) {
+        return { success: true, results: [] };
+      }
+      const results = await metadataProvider.search(trimmed, searchMode);
+      return { success: true, results };
+    } catch (error) {
+      return toErrorResponse(error, '剧名搜索失败');
+    }
   });
 
   ipcMain.handle('app:getVersion', () => app.getVersion());

--- a/electron/matchers/LLMEngine.ts
+++ b/electron/matchers/LLMEngine.ts
@@ -3,6 +3,14 @@ import { ILLMProvider } from '../interfaces/ILLMProvider';
 import path from 'path';
 import type { EpisodeData } from '../interfaces/IMetadataProvider';
 
+export interface DirectoryResolveHints {
+  currentDirName?: string;
+  parentDirName?: string;
+  seriesNameHint?: string;
+  seasonHint?: number;
+  targetFilename?: string;
+}
+
 export class LLMEngine implements IMatcher {
   private llm: ILLMProvider;
 
@@ -50,13 +58,33 @@ export class LLMEngine implements IMatcher {
     }
   }
 
-  async resolveDirectory(dirPath: string, filenames: string[]): Promise<{ seriesName?: string, season?: number, matches: Array<{ filename: string, episode: number }> }> {
+  async resolveDirectory(
+    dirPath: string,
+    filenames: string[],
+    hints?: DirectoryResolveHints
+  ): Promise<{ seriesName?: string, season?: number, matches: Array<{ filename: string, episode: number }> }> {
+    const hintSection = hints ? `
+      Additional Hints:
+      - Current Directory Name: "${hints.currentDirName ?? ''}"
+      - Parent Directory Name: "${hints.parentDirName ?? ''}"
+      - Series Name Hint: "${hints.seriesNameHint ?? ''}"
+      - Season Hint: ${hints.seasonHint ?? 'unknown'}
+      - Target Filename: "${hints.targetFilename ?? ''}"
+    ` : '';
+
     const prompt = `
       Analyze the following directory path and its video files to identify the TV series and match each file to an episode number.
       
       Directory Path: "${dirPath}"
       Files:
       ${filenames.map(f => `- ${f}`).join('\n')}
+      ${hintSection}
+
+      Important rules:
+      - "seriesName" must be the show title, not a season token.
+      - Never use values like "S01", "S1", "Season 1", "第1季", "Specials", "SP", "OVA" as "seriesName".
+      - If the current directory is a season folder, prefer parent directory (or provided Series Name Hint) as the "seriesName".
+      - If a valid season hint is provided, prefer it for "season".
       
       Return a JSON object with this exact structure:
       {
@@ -69,7 +97,7 @@ export class LLMEngine implements IMatcher {
     `;
 
     try {
-      this.logDebug(`[ResolveDirectory] Prompting for ${dirPath}`, { filenames });
+      this.logDebug(`[ResolveDirectory] Prompting for ${dirPath}`, { filenames, hints });
       const result = await this.llm.generateJson<{
         seriesName?: string;
         season?: number;

--- a/electron/services/ScannerService.ts
+++ b/electron/services/ScannerService.ts
@@ -535,17 +535,24 @@ export class ScannerService {
       }
     }
 
-    const { confirmed, options, selectedIndices, updatedMatches } =
+    const { confirmed, options, selectedIndices, updatedMatches, seriesId, seriesName: overrideSeriesName, seriesPoster, mediaType: overrideMediaType } =
       await this.requestEpisodesConfirmation(confirmedSeriesName, matchedItems);
     if (this.cancelRequested) return;
     if (confirmed && selectedIndices.length > 0) {
+      const finalSeriesName = overrideSeriesName?.trim() || confirmedSeriesName;
+      const finalSeriesInfo: CachedSeriesInfo = {
+        ...seriesInfo,
+        id: seriesId || seriesInfo.id,
+        poster: seriesPoster ?? seriesInfo.poster,
+        mediaType: overrideMediaType ?? seriesInfo.mediaType,
+      };
       await this.executeBatch(
         source,
-        confirmedSeriesName,
+        finalSeriesName,
         updatedMatches || matchedItems,
         selectedIndices,
         options ?? { rename: true, writeNfo: true, writePoster: true, writeStill: true },
-        seriesInfo,
+        finalSeriesInfo,
       );
     }
   }

--- a/electron/services/ScannerService.ts
+++ b/electron/services/ScannerService.ts
@@ -1,6 +1,6 @@
 import { IMediaSource, type BatchRenameItem, type FileItem } from '../interfaces/IMediaSource';
 import { RegexEngine } from '../matchers/RegexEngine';
-import { LLMEngine } from '../matchers/LLMEngine';
+import { LLMEngine, type DirectoryResolveHints } from '../matchers/LLMEngine';
 import { IMetadataProvider, type EpisodeData, type SearchResult } from '../interfaces/IMetadataProvider';
 import { DatabaseService } from './DatabaseService';
 import { BrowserWindow, ipcMain } from 'electron';
@@ -29,6 +29,12 @@ type UserConfirmationResult = {
   confirmedName?: string;
   mediaType?: MediaType;
   searchMode?: MediaSearchMode;
+};
+
+type DirectoryResolveResult = {
+  seriesName?: string;
+  season?: number;
+  matches: Array<{ filename: string; episode: number }>;
 };
 
 export class ScannerService {
@@ -214,6 +220,92 @@ export class ScannerService {
     return results;
   }
 
+  private parseSeasonToken(value?: string): number | null {
+    if (!value) return null;
+    const normalized = value.trim();
+    if (!normalized) return null;
+
+    const tokenPatterns: RegExp[] = [
+      /^s(?:eason)?[\s._-]*0*(\d{1,2})$/i,
+      /^season[\s._-]*0*(\d{1,2})$/i,
+      /^第?\s*0*(\d{1,2})\s*季$/i,
+    ];
+
+    for (const pattern of tokenPatterns) {
+      const match = normalized.match(pattern);
+      if (match?.[1]) return parseInt(match[1], 10);
+    }
+
+    if (/^(specials?|sp|ova|oad|特别篇|特典)$/i.test(normalized)) {
+      return 0;
+    }
+
+    return null;
+  }
+
+  private isSeasonLikeName(value?: string): boolean {
+    return this.parseSeasonToken(value) !== null;
+  }
+
+  private buildDirectoryResolveHints(
+    pathApi: Pick<typeof path, 'dirname' | 'basename'>,
+    dirPath: string,
+    targetFilename?: string
+  ): DirectoryResolveHints {
+    const currentDirName = pathApi.basename(dirPath)?.trim();
+    const parentDirPath = pathApi.dirname(dirPath);
+    const parentDirName = parentDirPath && parentDirPath !== dirPath
+      ? pathApi.basename(parentDirPath)?.trim()
+      : undefined;
+
+    const seasonFromCurrent = this.parseSeasonToken(currentDirName);
+    const seasonFromParent = this.parseSeasonToken(parentDirName);
+
+    let seriesNameHint: string | undefined;
+    let seasonHint: number | undefined;
+
+    if (seasonFromCurrent !== null && parentDirName && !this.isSeasonLikeName(parentDirName)) {
+      seriesNameHint = parentDirName;
+      seasonHint = seasonFromCurrent;
+    } else if (currentDirName && !this.isSeasonLikeName(currentDirName)) {
+      seriesNameHint = currentDirName;
+    }
+
+    if (seasonHint === undefined && seasonFromParent !== null) {
+      seasonHint = seasonFromParent;
+    }
+
+    return {
+      currentDirName: currentDirName || undefined,
+      parentDirName: parentDirName || undefined,
+      seriesNameHint,
+      seasonHint,
+      targetFilename,
+    };
+  }
+
+  private sanitizeDirectoryResolveResult(
+    input: DirectoryResolveResult,
+    hints: DirectoryResolveHints
+  ): DirectoryResolveResult {
+    const sanitized = { ...input };
+    const trimmedSeriesName = sanitized.seriesName?.trim();
+
+    if (!trimmedSeriesName || this.isSeasonLikeName(trimmedSeriesName)) {
+      sanitized.seriesName = hints.seriesNameHint;
+    } else {
+      sanitized.seriesName = trimmedSeriesName;
+    }
+
+    const seasonValue = typeof sanitized.season === 'number' && Number.isFinite(sanitized.season)
+      ? Math.max(0, Math.trunc(sanitized.season))
+      : undefined;
+
+    sanitized.season = seasonValue ?? hints.seasonHint;
+
+    return sanitized;
+  }
+
   async identifySingleFile(source: IMediaSource, targetPath: string, videoExtensions: string) {
     if (this._isScanning) return;
     this._isScanning = true;
@@ -233,7 +325,9 @@ export class ScannerService {
 
       // Call LLM with directory context
       this.log('正在请求 LLM 根据目录上下文识别剧集信息...');
-      const resolveResult = await this.llmEngine.resolveDirectory(dirPath, videoFiles.map(f => f.name));
+      const dirHints = this.buildDirectoryResolveHints(pathApi, dirPath, pathApi.basename(targetPath));
+      const rawResolveResult = await this.llmEngine.resolveDirectory(dirPath, videoFiles.map(f => f.name), dirHints);
+      const resolveResult = this.sanitizeDirectoryResolveResult(rawResolveResult, dirHints);
 
       if (!resolveResult.seriesName) {
         this.log('LLM 无法识别该剧集。', 'error');
@@ -760,7 +854,9 @@ export class ScannerService {
         } else {
           // 使用 LLM 识别
           this.log(`正在尝试对目录 ${dir} (${unmatchedFiles.length} 个文件) 进行智能识别...`);
-          const dirResolve = await this.llmEngine.resolveDirectory(dir, unmatchedFiles.map(f => f.name));
+          const dirHints = this.buildDirectoryResolveHints(path.posix, dir);
+          const rawDirResolve = await this.llmEngine.resolveDirectory(dir, unmatchedFiles.map(f => f.name), dirHints);
+          const dirResolve = this.sanitizeDirectoryResolveResult(rawDirResolve, dirHints);
 
           if (dirResolve.seriesName) {
             for (const unmatched of unmatchedFiles) {

--- a/shared/ipc.ts
+++ b/shared/ipc.ts
@@ -93,6 +93,15 @@ export type FetchMetadataResponse = AsyncResult<{
   matches: EpisodeMatchItem[];
 }>;
 
+export interface SeriesSearchRequest {
+  query: string;
+  searchMode: MediaSearchMode;
+}
+
+export type SeriesSearchResponse = AsyncResult<{
+  results: SearchResult[];
+}>;
+
 export interface SmartIdentifyRequest {
   unmatchedFiles: EpisodeMatchItem[];
 }
@@ -154,6 +163,10 @@ export interface ScannerEpisodesConfirmResponsePayload {
   options?: BatchOptions;
   selectedIndices: number[];
   updatedMatches?: EpisodeMatchItem[];
+  seriesId?: string;
+  seriesName?: string;
+  seriesPoster?: string;
+  mediaType?: MediaType;
 }
 
 export interface RendererEventPayloadMap {
@@ -179,6 +192,7 @@ export interface WindowIpcRenderer {
   invoke(channel: 'explorer:list', request: ExplorerListRequest): Promise<ExplorerListResponse>;
   invoke(channel: 'llm:test', request: LlmTestRequest): Promise<LlmTestResponse>;
   invoke(channel: 'media:getAll'): Promise<ScrapedMediaRecord[]>;
+  invoke(channel: 'metadata:searchSeries', request: SeriesSearchRequest): Promise<SeriesSearchResponse>;
   invoke(channel: 'metadata:getEpisodeDetail', request: MetadataDetailRequest): Promise<EpisodeData | null>;
   invoke(channel: 'openlist:test', request: OpenListTestRequest): Promise<AsyncResult<Record<string, never>>>;
   invoke(channel: 'proxy:test'): Promise<AsyncResult<Record<string, never>>>;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,8 @@ type WizardState = {
   notice?: string;
   seriesName?: string;
   seriesId?: string;
+  seriesPoster?: string;
+  seriesMediaType?: 'tv' | 'movie';
   matches?: EpisodeMatchItem[];
 };
 
@@ -453,6 +455,7 @@ export default function App() {
   const [editingMatchIndex, setEditingMatchIndex] = useState<number | null>(null);
   const [editMatchValues, setEditMatchValues] = useState({ season: 1, episode: 1 });
   const [manualSeriesName, setManualSeriesName] = useState('');
+  const [seriesReselectMode, setSeriesReselectMode] = useState(false);
 
   // Batch edit states
   const [batchEditMode, setBatchEditMode] = useState<'season' | 'episode' | null>(null);
@@ -565,6 +568,7 @@ export default function App() {
       refreshMedia();
     };
     const handleConfirmation = (data: ScannerRequireConfirmationPayload) => {
+      setSeriesReselectMode(false);
       setMetadataFetched(false);
       setFetchingMetadata(false);
       setMetadataProgress({ current: 0, total: 0 });
@@ -578,6 +582,7 @@ export default function App() {
       setWizardWizardStage('series');
     };
     const handleEpisodesConfirmation = (data: EpisodeConfirmationPayload) => {
+      setSeriesReselectMode(false);
       setMetadataFetched(false);
       setFetchingMetadata(false);
       setMetadataProgress({ current: 0, total: 0 });
@@ -585,6 +590,8 @@ export default function App() {
         ...prev,
         seriesName: data.seriesName,
         seriesId: data.matches[0]?.tmdbId,
+        seriesPoster: prev.seriesPoster,
+        seriesMediaType: prev.seriesMediaType,
         matches: data.matches
       }));
       setSelectedIndices(data.matches.map((_, i) => i));
@@ -666,7 +673,77 @@ export default function App() {
   }, [theme]);
 
   // Handlers
-  const handleConfirmSeries = (selected: SearchResult | null) => {
+  const searchSeriesResults = async (query: string, mode: MediaSearchMode) => {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) return;
+
+    setWizardData(prev => ({
+      ...prev,
+      detectedName: trimmedQuery,
+      searchMode: mode,
+      seriesResults: undefined,
+      notice: undefined,
+    }));
+
+    try {
+      const result = await window.ipcRenderer.invoke('metadata:searchSeries', {
+        query: trimmedQuery,
+        searchMode: mode,
+      });
+
+      if (result.success) {
+        setWizardData(prev => ({
+          ...prev,
+          detectedName: trimmedQuery,
+          searchMode: mode,
+          seriesResults: result.results,
+          notice: undefined,
+        }));
+      } else {
+        setWizardData(prev => ({
+          ...prev,
+          detectedName: trimmedQuery,
+          searchMode: mode,
+          seriesResults: [],
+          notice: result.error || '搜索失败，请重试。',
+        }));
+      }
+    } catch {
+      setWizardData(prev => ({
+        ...prev,
+        detectedName: trimmedQuery,
+        searchMode: mode,
+        seriesResults: [],
+        notice: '搜索失败，请重试。',
+      }));
+    }
+  };
+
+  const handleConfirmSeries = async (selected: SearchResult | null) => {
+    if (seriesReselectMode) {
+      if (!selected?.id || !wizardData.matches) return;
+
+      const updatedMatches = wizardData.matches.map((item) => ({
+        ...item,
+        tmdbId: selected.id,
+      }));
+
+      setWizardData(prev => ({
+        ...prev,
+        seriesName: selected.title,
+        seriesId: selected.id,
+        seriesPoster: selected.poster,
+        seriesMediaType: selected.mediaType,
+        matches: updatedMatches,
+      }));
+
+      setWizardWizardStage('loading_episodes');
+      await handleFetchMetadataWithData(updatedMatches, selected.id);
+      setWizardWizardStage('episodes');
+      setSeriesReselectMode(false);
+      return;
+    }
+
     window.ipcRenderer.send('scanner-confirm-response', {
       seriesId: selected?.id ?? null,
       seriesName: selected?.title, // 添加用户确认的剧集名称
@@ -685,6 +762,11 @@ export default function App() {
   const handleManualSearch = () => {
     if (!manualSeriesName.trim()) return;
 
+    if (seriesReselectMode) {
+      void searchSeriesResults(manualSeriesName, wizardData.searchMode ?? 'auto');
+      return;
+    }
+
     // Send IPC request with new name
     window.ipcRenderer.send('scanner-confirm-response', {
       seriesId: null,
@@ -699,6 +781,17 @@ export default function App() {
   const handleSearchModeChange = (mode: MediaSearchMode) => {
     if ((wizardData.searchMode ?? 'auto') === mode) return;
     setWizardData(prev => ({ ...prev, searchMode: mode, seriesResults: undefined, notice: undefined }));
+
+    if (seriesReselectMode) {
+      const query = manualSeriesName.trim() || wizardData.detectedName || wizardData.seriesName;
+      if (query) {
+        void searchSeriesResults(query, mode);
+      } else {
+        setWizardData(prev => ({ ...prev, seriesResults: [] }));
+      }
+      return;
+    }
+
     window.ipcRenderer.send('scanner-confirm-response', {
       seriesId: null,
       searchMode: mode,
@@ -708,17 +801,49 @@ export default function App() {
   const handleConfirmEpisodes = (confirmed: boolean) => {
     if (!confirmed) {
       window.ipcRenderer.send('scanner-episodes-confirm-response', { confirmed: false, selectedIndices: [] });
+      setSeriesReselectMode(false);
       setWizardWizardStage('idle'); setWizardData({});
     } else {
       setWizardWizardStage('executing');
       setScrapeProgress({ percent: 0, message: '正在初始化操作...' });
-      window.ipcRenderer.send('scanner-episodes-confirm-response', { confirmed: true, options: batchOptions, selectedIndices: selectedIndices, updatedMatches: wizardData.matches });
+      window.ipcRenderer.send('scanner-episodes-confirm-response', {
+        confirmed: true,
+        options: batchOptions,
+        selectedIndices: selectedIndices,
+        updatedMatches: wizardData.matches,
+        seriesId: wizardData.seriesId,
+        seriesName: wizardData.seriesName,
+        seriesPoster: wizardData.seriesPoster,
+        mediaType: wizardData.seriesMediaType,
+      });
     }
+  };
+
+  const handleReopenSeriesSelection = () => {
+    if (!wizardData.matches) return;
+    setSeriesReselectMode(true);
+    setManualSeriesName(wizardData.seriesName || wizardData.detectedName || '');
+    setWizardData(prev => ({
+      ...prev,
+      detectedName: prev.seriesName || prev.detectedName,
+      searchMode: prev.searchMode ?? 'auto',
+      notice: '已返回剧名选择。你可以重新自动搜索或手动输入剧名。',
+    }));
+    setWizardWizardStage('series');
+  };
+
+  const handleCancelSeriesReselect = () => {
+    setSeriesReselectMode(false);
+    setWizardWizardStage('episodes');
   };
 
   const closeWizard = () => {
     if (wizardStage === 'series') {
-      window.ipcRenderer.send('scanner-confirm-response', { seriesId: null });
+      if (seriesReselectMode) {
+        window.ipcRenderer.send('scanner-episodes-confirm-response', { confirmed: false, selectedIndices: [] });
+      } else {
+        window.ipcRenderer.send('scanner-confirm-response', { seriesId: null });
+      }
     }
     if (wizardStage === 'episodes') {
       window.ipcRenderer.send('scanner-episodes-confirm-response', { confirmed: false, selectedIndices: [] });
@@ -730,6 +855,7 @@ export default function App() {
     setMetadataFetched(false);
     setFetchingMetadata(false);
     setMetadataProgress({ current: 0, total: 0 });
+    setSeriesReselectMode(false);
 
     if (wizardStage === 'finished') {
       setScanning(false);
@@ -749,6 +875,7 @@ export default function App() {
       setMetadataFetched(false);
       setFetchingMetadata(false);
       setMetadataProgress({ current: 0, total: 0 });
+      setSeriesReselectMode(false);
       setScanning(false);
     }
   };
@@ -2099,7 +2226,15 @@ export default function App() {
                   {wizardStage === 'episodes' && (
                     <span>
                       {isMovieWorkflow ? '电影' : '剧集'}：
-                      <span className="text-blue-500 font-bold"> {wizardData.seriesName}</span> •
+                      <button
+                        type="button"
+                        onClick={handleReopenSeriesSelection}
+                        className="text-blue-500 font-bold hover:text-blue-400 underline decoration-dotted underline-offset-2 ml-1"
+                        title="点击重新选择剧名"
+                      >
+                        {wizardData.seriesName}
+                      </button>
+                      {' '}•
                       <span className="font-bold"> {selectedIndices.length}</span> 个项目
                     </span>
                   )}
@@ -2144,6 +2279,14 @@ export default function App() {
                     <button onClick={handleManualSearch} disabled={!manualSeriesName.trim()} className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded-lg text-xs font-bold transition-all shadow-lg shadow-blue-500/20 disabled:opacity-50 disabled:cursor-not-allowed">
                       重试
                     </button>
+                    {seriesReselectMode && (
+                      <button
+                        onClick={handleCancelSeriesReselect}
+                        className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-slate-600 dark:text-slate-300 px-4 py-2 rounded-lg text-xs font-bold"
+                      >
+                        返回审查
+                      </button>
+                    )}
                   </div>
                 </div>
                 {wizardData.notice && (
@@ -2173,7 +2316,7 @@ export default function App() {
                     </div>
                   </div>
                 ))}
-                {wizardData.seriesResults && <button onClick={() => handleConfirmSeries(null)} className="w-full p-4 border-2 border-dashed rounded-xl text-sm font-bold text-slate-400">跳过并使用原文件名</button>}
+                {wizardData.seriesResults && !seriesReselectMode && <button onClick={() => handleConfirmSeries(null)} className="w-full p-4 border-2 border-dashed rounded-xl text-sm font-bold text-slate-400">跳过并使用原文件名</button>}
               </div>
             )}
             {wizardStage === 'loading_episodes' && <div className="flex-1 py-20 flex flex-col items-center justify-center space-y-4"><RefreshCw className="w-10 h-10 text-blue-500 animate-spin" /><p className="font-bold">正在获取详细信息...</p></div>}


### PR DESCRIPTION
## Summary
This PR fixes two related scanner UX/recognition issues:

1. Fix season-folder misdetection in 3-level paths (e.g. House M.D./S01/S01E01.mp4 where S01 was incorrectly detected as series title).
2. Allow re-selecting the series name from the **Review & Execute** step by clicking the blue series name and returning to the series selection/search step.

## Changes
- Add directory resolve hints and stronger LLM constraints to avoid season tokens as series name.
- Add result sanitization fallback to path-derived series hints.
- Add UI flow/state to re-open series selection from review stage.
- Add IPC endpoint metadata:searchSeries for in-review series re-search.
- Extend episode confirmation payload to carry series override fields and apply them during execution.

## Testing
- 
px tsc --noEmit
- 
pm run lint

## Issue Link
Fixes #61